### PR TITLE
Query assignment and subscription

### DIFF
--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -45,6 +45,10 @@ int64ToOffset o
     | otherwise  = PartitionOffsetInvalid
 {-# INLINE int64ToOffset #-}
 
+fromNativeTopicPartitionList'' :: RdKafkaTopicPartitionListTPtr -> IO [TopicPartition]
+fromNativeTopicPartitionList'' ptr =
+    withForeignPtr ptr $ \fptr -> fromNativeTopicPartitionList' fptr
+
 fromNativeTopicPartitionList' :: Ptr RdKafkaTopicPartitionListT -> IO [TopicPartition]
 fromNativeTopicPartitionList' ppl = peek ppl >>= fromNativeTopicPartitionList
 

--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -4,6 +4,7 @@ where
 
 import           Control.Monad
 import qualified Data.ByteString        as BS
+import           Data.Map.Strict        (Map, fromListWith)
 import           Foreign
 import           Foreign.C.Error
 import           Foreign.C.String
@@ -82,6 +83,9 @@ topicPartitionFromMessage :: ConsumerRecord k v -> TopicPartition
 topicPartitionFromMessage m =
   let (Offset moff) = crOffset m
    in TopicPartition (crTopic m) (crPartition m) (PartitionOffset moff)
+
+toMap :: Ord k => [(k, v)] -> Map k [v]
+toMap kvs = fromListWith (++) [(k, [v]) | (k, v) <- kvs]
 
 fromMessagePtr :: RdKafkaMessageTPtr -> IO (Either KafkaError (ConsumerRecord (Maybe BS.ByteString) (Maybe BS.ByteString)))
 fromMessagePtr ptr =

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -24,6 +24,11 @@ newtype Millis          = Millis Int deriving (Show, Read, Eq, Ord, Num)
 newtype ClientId        = ClientId String deriving (Show, Eq, Ord)
 data OffsetReset        = Earliest | Latest deriving (Show, Eq)
 
+data SubscribedPartitions
+  = SubscribedPartitions [PartitionId]
+  | SubscribedPartitionsAll
+  deriving (Show, Eq)
+
 data Timestamp =
     CreateTime !Millis
   | LogAppendTime !Millis

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -488,9 +488,18 @@ newRdKafkaQueue k = do
     {`RdKafkaTPtr'}
     -> `RdKafkaRespErrT' cIntToEnum #}
 
-{#fun rd_kafka_subscription as ^
+{#fun rd_kafka_subscription as rdKafkaSubscription'
     {`RdKafkaTPtr', castPtr `Ptr (Ptr RdKafkaTopicPartitionListT)'}
     -> `RdKafkaRespErrT' cIntToEnum #}
+
+rdKafkaSubscription :: RdKafkaTPtr -> IO (Either RdKafkaRespErrT RdKafkaTopicPartitionListTPtr)
+rdKafkaSubscription k = alloca $ \psPtr -> do
+    err <- rdKafkaSubscription' k psPtr
+    case err of
+        RdKafkaRespErrNoError -> do
+            lst <- peek psPtr >>= newForeignPtr rdKafkaTopicPartitionListDestroy
+            return (Right lst)
+        e -> return (Left e)
 
 {#fun rd_kafka_consumer_poll as ^
     {`RdKafkaTPtr', `Int'} -> `RdKafkaMessageTPtr' #}
@@ -512,9 +521,18 @@ pollRdKafkaConsumer k t = do
     {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'}
     -> `RdKafkaRespErrT' cIntToEnum #}
 
-{#fun rd_kafka_assignment as ^
+{#fun rd_kafka_assignment as rdKafkaAssignment'
     {`RdKafkaTPtr', castPtr `Ptr (Ptr RdKafkaTopicPartitionListT)'}
     -> `RdKafkaRespErrT' cIntToEnum #}
+
+rdKafkaAssignment :: RdKafkaTPtr -> IO (Either RdKafkaRespErrT RdKafkaTopicPartitionListTPtr)
+rdKafkaAssignment k = alloca $ \psPtr -> do
+    err <- rdKafkaAssignment' k psPtr
+    case err of
+        RdKafkaRespErrNoError -> do
+            lst <- peek psPtr >>= newForeignPtr rdKafkaTopicPartitionListDestroy
+            return (Right lst)
+        e -> return (Left e)
 
 {#fun rd_kafka_commit as ^
     {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr', boolToCInt `Bool'}

--- a/src/Kafka/Internal/Shared.hs
+++ b/src/Kafka/Internal/Shared.hs
@@ -44,9 +44,3 @@ kafkaErrorToMaybe err = case err of
 maybeToLeft :: Maybe a -> Either a ()
 maybeToLeft = maybe (Right ()) Left
 {-# INLINE maybeToLeft #-}
-
-mapLeft :: (a -> a') -> Either a b -> Either a' b
-mapLeft f e = case e of
-  Left a  -> Left (f a)
-  Right b -> Right b
-{-# INLINE mapLeft #-}


### PR DESCRIPTION
## Changes

- Implemented `subscription` and `assignment` (#15)
- Using `assignment` on MacOS causes an error on consumer close, reported as `librdkafka` bug here: https://github.com/edenhill/librdkafka/issues/1000