### PR TITLE
Add (and correct) Semigroup for ConsumerProperties, ProducerProperties

### DIFF
--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -61,6 +61,9 @@ library
                      , temporary
                      , transformers
                      , unix
+  if impl(ghc < 8.0)
+    build-depends: semigroups
+
   exposed-modules:
     Kafka.Types
     Kafka.Consumer.ConsumerProperties


### PR DESCRIPTION
* Added `Semigroup ConsumerProperties`, `Semigroup ProducerProperties`
* Corrected usage of `M.union` so that `(<>)` is right biased.