### PR TITLE
Correct parameters passed in for commitAllOffsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ processMessages kafka = do
     mapM_ (\_ -> do
                    msg1 <- pollMessage kafka (Timeout 1000)
                    putStrLn $ "Message: " <> show msg1
-                   err <- commitAllOffsets kafka OffsetCommit
+                   err <- commitAllOffsets OffsetCommit kafka
                    putStrLn $ "Offsets: " <> maybe "Committed." show err
           ) [0 .. 10]
     return $ Right ()


### PR DESCRIPTION
The type for `commitAllOffsets` is:
```
commitAllOffsets :: MonadIO m
                 => OffsetCommit
                 -> KafkaConsumer
                 -> m (Maybe KafkaError)
```

In the Consumer example the parameters were passed in the other way around.