### PR TITLE
Async poll for events on both consumer and producer sides

### DIFF
--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -1,5 +1,5 @@
 name:                hw-kafka-client
-version:             2.0.4
+version:             2.1.0
 homepage:            https://github.com/haskell-works/hw-kafka-client
 bug-reports:         https://github.com/haskell-works/hw-kafka-client/issues
 license:             MIT
@@ -78,6 +78,7 @@ library
     Kafka.Callbacks
     Kafka.Consumer.Convert
     Kafka.Consumer.Callbacks
+    Kafka.Internal.CancellationToken
     Kafka.Internal.Shared
     Kafka.Internal.Setup
     Kafka.Producer.Convert

--- a/scripts/hackage-docs.sh
+++ b/scripts/hackage-docs.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+# This if stack-enabled fork of https://github.com/ekmett/lens/blob/master/scripts/hackage-docs.sh
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: scripts/hackage-docs.sh HACKAGE_USER"
+  exit 1
+fi
+
+user=$1
+
+cabal_file=$(find . -maxdepth 1 -name "*.cabal" -print -quit)
+if [ ! -f "$cabal_file" ]; then
+  echo "Run this script in the top-level package directory"
+  exit 1
+fi
+
+pkg=$(awk -F ":[[:space:]]*" 'tolower($1)=="name"    { print $2 }' < "$cabal_file")
+ver=$(awk -F ":[[:space:]]*" 'tolower($1)=="version" { print $2 }' < "$cabal_file")
+
+if [ -z "$pkg" ]; then
+  echo "Unable to determine package name"
+  exit 1
+fi
+
+if [ -z "$ver" ]; then
+  echo "Unable to determine package version"
+  exit 1
+fi
+
+echo "Detected package: $pkg-$ver"
+
+dir=$(mktemp -d build-docs.XXXXXX)
+trap 'rm -r "$dir"' EXIT
+
+export PATH=$(stack path --bin-path)
+
+ghc --version
+cabal --version
+stack --version
+
+if haddock --hyperlinked-source >/dev/null
+then
+  echo "Using fancy hyperlinked source"
+  HYPERLINK_FLAG="--haddock-option=--hyperlinked-source"
+else
+  echo "Using boring hyperlinked source"
+  HYPERLINK_FLAG="--hyperlink-source"
+fi
+
+# Cabal dist in temporary location
+builddir=$dir/dist
+
+# Build dependencies haddocks with stack, so we get links
+stack haddock --only-dependencies
+
+# Configure using stack databases
+snapshotpkgdb=$(stack path --snapshot-pkg-db)
+localpkgdb=$(stack path --local-pkg-db)
+cabal configure -v2 --builddir=$builddir --package-db=clear --package-db=global --package-db=$snapshotpkgdb --package-db=$localpkgdb
+
+# Build Hadckage compatible docs
+cabal haddock -v2 --builddir=$builddir $HYPERLINK_FLAG --html-location='/package/$pkg-$version/docs' --contents-location='/package/$pkg-$version'
+
+# Copy into right directory
+cp -R $builddir/doc/html/$pkg/ $dir/$pkg-$ver-docs
+
+# Tar and gzip
+tar cvz -C $dir --format=ustar -f $dir/$pkg-$ver-docs.tar.gz $pkg-$ver-docs
+
+# Upload
+curl -X PUT \
+     -H 'Content-Type: application/x-tar' \
+     -H 'Content-Encoding: gzip' \
+     -u "$user" \
+     --data-binary "@$dir/$pkg-$ver-docs.tar.gz" \
+     "https://hackage.haskell.org/package/$pkg-$ver/docs"

--- a/src/Kafka/Callbacks.hs
+++ b/src/Kafka/Callbacks.hs
@@ -9,12 +9,12 @@ import Kafka.Types
 
 errorCallback :: HasKafkaConf k => (KafkaError -> String -> IO ()) -> k -> IO ()
 errorCallback callback k =
-  let (KafkaConf c) = getKafkaConf k
+  let (KafkaConf c _) = getKafkaConf k
       realCb _ err = callback (KafkaResponseError err)
   in rdKafkaConfSetErrorCb c realCb
 
 logCallback :: HasKafkaConf k => (Int -> String -> String -> IO ()) -> k -> IO ()
 logCallback callback k =
-  let (KafkaConf c) = getKafkaConf k
+  let (KafkaConf c _) = getKafkaConf k
       realCb _ = callback
   in rdKafkaConfSetLogCb c realCb

--- a/src/Kafka/Consumer/Callbacks.hs
+++ b/src/Kafka/Consumer/Callbacks.hs
@@ -25,12 +25,12 @@ import Kafka.Types
 --
 --     * When 'RdKafkaRespErrRevokePartitions' happens 'assign' should be called with an empty list of partitions.
 rebalanceCallback :: (KafkaConsumer -> KafkaError -> [TopicPartition] -> IO ()) -> KafkaConf -> IO ()
-rebalanceCallback callback (KafkaConf conf) = rdKafkaConfSetRebalanceCb conf realCb
+rebalanceCallback callback (KafkaConf conf ct) = rdKafkaConfSetRebalanceCb conf realCb
   where
     realCb k err pl = do
       k' <- newForeignPtr_ k
       pls <- fromNativeTopicPartitionList' pl
-      callback (KafkaConsumer (Kafka k') (KafkaConf conf)) (KafkaResponseError err) pls
+      callback (KafkaConsumer (Kafka k') (KafkaConf conf ct)) (KafkaResponseError err) pls
 
 -- | Sets a callback that is called when rebalance is needed.
 --
@@ -43,10 +43,10 @@ rebalanceCallback callback (KafkaConf conf) = rdKafkaConfSetRebalanceCb conf rea
 -- with `KafkaError` == `KafkaResponseError` `RdKafkaRespErrNoOffset` which is not to be considered
 -- an error.
 offsetCommitCallback :: (KafkaConsumer -> KafkaError -> [TopicPartition] -> IO ()) -> KafkaConf -> IO ()
-offsetCommitCallback callback (KafkaConf conf) = rdKafkaConfSetOffsetCommitCb conf realCb
+offsetCommitCallback callback (KafkaConf conf ct) = rdKafkaConfSetOffsetCommitCb conf realCb
   where
     realCb k err pl = do
       k' <- newForeignPtr_ k
       pls <- fromNativeTopicPartitionList' pl
-      callback (KafkaConsumer (Kafka k') (KafkaConf conf)) (KafkaResponseError err) pls
+      callback (KafkaConsumer (Kafka k') (KafkaConf conf ct)) (KafkaResponseError err) pls
 

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Kafka.Consumer.Types
 
 where
@@ -11,7 +10,10 @@ import Data.Int
 import Data.Typeable
 import Kafka.Types
 
-data KafkaConsumer = KafkaConsumer { kcKafkaPtr :: !Kafka, kcKafkaConf :: !KafkaConf} deriving (Show)
+data KafkaConsumer = KafkaConsumer
+  { kcKafkaPtr  :: !Kafka
+  , kcKafkaConf :: !KafkaConf
+  }
 
 instance HasKafka KafkaConsumer where
   getKafka = kcKafkaPtr

--- a/src/Kafka/Internal/CancellationToken.hs
+++ b/src/Kafka/Internal/CancellationToken.hs
@@ -1,0 +1,17 @@
+module Kafka.Internal.CancellationToken
+where
+
+import Data.IORef
+
+data CancellationStatus = Cancelled | Running deriving (Show, Eq)
+newtype CancellationToken = CancellationToken (IORef CancellationStatus)
+
+newCancellationToken :: IO CancellationToken
+newCancellationToken = CancellationToken <$> newIORef Running
+
+status :: CancellationToken -> IO CancellationStatus
+status (CancellationToken ref) = readIORef ref
+
+cancel :: CancellationToken -> IO ()
+cancel (CancellationToken ref) = atomicWriteIORef ref Cancelled
+

--- a/src/Kafka/Internal/Setup.hs
+++ b/src/Kafka/Internal/Setup.hs
@@ -7,6 +7,7 @@ import Control.Exception
 import Control.Monad
 import Foreign
 import Foreign.C.String
+import Kafka.Internal.CancellationToken
 
 --
 -- Configuration
@@ -18,7 +19,7 @@ newTopicConf :: IO TopicConf
 newTopicConf = TopicConf <$> newRdKafkaTopicConfT
 
 newKafkaConf :: IO KafkaConf
-newKafkaConf = KafkaConf <$> newRdKafkaConfT
+newKafkaConf = KafkaConf <$> newRdKafkaConfT <*> newCancellationToken
 
 kafkaConf :: KafkaProps -> IO KafkaConf
 kafkaConf overrides = do
@@ -43,7 +44,7 @@ checkConfSetValue err charPtr = case err of
       throw $ KafkaUnknownConfigurationKey str
 
 setKafkaConfValue :: KafkaConf -> String -> String -> IO ()
-setKafkaConfValue (KafkaConf confPtr) key value =
+setKafkaConfValue (KafkaConf confPtr _) key value =
   allocaBytes nErrorBytes $ \charPtr -> do
     err <- rdKafkaConfSet confPtr key value charPtr (fromIntegral nErrorBytes)
     checkConfSetValue err charPtr

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -12,7 +12,7 @@ data KafkaProducer = KafkaProducer
   { kpKafkaPtr  :: !Kafka
   , kpKafkaConf :: !KafkaConf
   , kpTopicConf :: !TopicConf
-  } deriving (Show)
+  }
 
 instance HasKafka KafkaProducer where
   getKafka = kpKafkaPtr

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -6,6 +6,7 @@ where
 import Control.Exception
 import Data.Int
 import Data.Typeable
+import Kafka.Internal.CancellationToken
 import Kafka.Internal.RdKafka
 
 class HasKafka a where
@@ -19,7 +20,7 @@ newtype BrokerId =
   deriving (Show, Eq, Ord, Read)
 
 newtype Kafka     = Kafka RdKafkaTPtr deriving Show
-newtype KafkaConf = KafkaConf RdKafkaConfTPtr deriving Show
+data KafkaConf    = KafkaConf RdKafkaConfTPtr CancellationToken
 newtype TopicConf = TopicConf RdKafkaTopicConfTPtr deriving Show
 
 newtype PartitionId = PartitionId Int deriving (Show, Eq, Read, Ord, Enum)

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 extra-deps:
 
-resolver: lts-9.1
+resolver: lts-9.11
 
 docker:
   enable: false


### PR DESCRIPTION
## Changes
- Implement `resumePartitions` (we already had `pausePartitions`
- Poll for events/callbacks asynchronously for both consumers and producers. This closes #7 and allows taking time while handling messages. 