### PR TITLE
[WIP] Fix the Example `kakfa-client-example`

### DIFF
--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -38,6 +38,7 @@ executable kafka-client-example
                      , ProducerExample
   hs-source-dirs:      example
   default-language:    Haskell2010
+  ghc-options:         -Wall -threaded
   build-depends:       base >=4.6 && < 5
                      , bifunctors
                      , bytestring


### PR DESCRIPTION
1. Run with `stack build --exec kafka-client-example --flag hw-kafka-client:examples`, but it halt here:

```
Running producer example...

```
Add `-threaded` to `ghc-options` of `kafka-client-example` to fix it.

2. After fix problem 1, it report the error:
```
Running producer example...
Right ()
Running consumer example...
Just KafkaLogInfo
Message: Left (KafkaResponseError RdKafkaRespErrTimedOut)
Process exited with ExitFailure (-11): /home/wangwangwar/code/haskell/hw-kafka-client/.stack-work/install/x86_64-linux-nopie/lts-9.11/8.0.2/bin/kafka-client-example
```