### PR TITLE
Implement delivery error callbacks

### DIFF
--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -1,5 +1,5 @@
 name:                hw-kafka-client
-version:             2.1.3
+version:             2.2.0
 homepage:            https://github.com/haskell-works/hw-kafka-client
 bug-reports:         https://github.com/haskell-works/hw-kafka-client/issues
 license:             MIT
@@ -46,6 +46,7 @@ executable kafka-client-example
                      , transformers
                      , unix
                      , hw-kafka-client
+  ghc-options:       -threaded -rtsopts
 
   if flag(examples)
     buildable: True
@@ -84,6 +85,7 @@ library
     Kafka.Internal.Setup
     Kafka.Internal.Shared
     Kafka.Producer.Convert
+    Kafka.Producer.Callbacks
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Kafka/Producer/Callbacks.hs
+++ b/src/Kafka/Producer/Callbacks.hs
@@ -1,0 +1,28 @@
+module Kafka.Producer.Callbacks
+( deliveryErrorsCallback
+, module X
+)
+where
+
+import Foreign
+import Foreign.C.Error
+import Kafka.Callbacks        as X
+import Kafka.Internal.RdKafka
+import Kafka.Internal.Setup
+import Kafka.Internal.Shared
+import Kafka.Types
+
+-- | Sets the callback for delivery errors.
+-- The callback is only called in case of errors.
+deliveryErrorsCallback :: (KafkaError -> IO ()) -> KafkaConf -> IO ()
+deliveryErrorsCallback callback (KafkaConf conf _) = rdKafkaConfSetDrMsgCb conf realCb
+  where
+    realCb :: t -> Ptr RdKafkaMessageT -> IO ()
+    realCb _ mptr =
+      if mptr == nullPtr
+        then getErrno >>= (callback . kafkaRespErr)
+        else do
+          s <- peek mptr
+          if err'RdKafkaMessageT s /= RdKafkaRespErrNoError
+            then (callback . KafkaResponseError $ err'RdKafkaMessageT s)
+            else pure ()

--- a/src/Kafka/Producer/ProducerProperties.hs
+++ b/src/Kafka/Producer/ProducerProperties.hs
@@ -1,15 +1,15 @@
 module Kafka.Producer.ProducerProperties
 ( module Kafka.Producer.ProducerProperties
-, module Kafka.Callbacks
+, module Kafka.Producer.Callbacks
 )
 where
 
 import           Control.Monad
-import qualified Data.List            as L
-import           Data.Map             (Map)
-import qualified Data.Map             as M
-import           Kafka.Callbacks
+import qualified Data.List                as L
+import           Data.Map                 (Map)
+import qualified Data.Map                 as M
 import           Kafka.Internal.Setup
+import           Kafka.Producer.Callbacks
 import           Kafka.Types
 
 -- | Properties to create 'KafkaProducer'.
@@ -53,6 +53,10 @@ compression c =
 topicCompression :: KafkaCompressionCodec -> ProducerProperties
 topicCompression c =
   extraTopicProps $ M.singleton "compression.codec" (kafkaCompressionCodecToString c)
+
+sendTimeout :: Timeout -> ProducerProperties
+sendTimeout (Timeout t) =
+  extraTopicProps $ M.singleton "message.timeout.ms" (show t)
 
 -- | Any configuration options that are supported by /librdkafka/.
 -- The full list can be found <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md here>


### PR DESCRIPTION
## Changes

- Implement `deliveryErrorsCallback` for Producer. The provided `KafkaError -> IO ()` function is going to be called whenever there is a delivery error.
- Remove async event loop from the producer side. This is to avoid race conditions: if delivery errors are handled asynchronously then the "main" thread still has time to do something undesired, like committing offsets. I'd rather handle delivery errors synchronously so there are no surprises.
- Poll for events (with no wait) before sending each new message
- Poll for events when producer flushes.