### PR TITLE
Consumer queue

### DIFF
--- a/example/ConsumerExample.hs
+++ b/example/ConsumerExample.hs
@@ -12,7 +12,7 @@ consumerProps :: ConsumerProperties
 consumerProps = brokersList [BrokerAddress "localhost:9092"]
              <> groupId (ConsumerGroupId "consumer_example_group")
              <> noAutoCommit
-             <> setCallback (rebalanceCallback (printingRebalanceCallback "ONE!"))
+             <> setCallback (rebalanceCallback printingRebalanceCallback)
              <> setCallback (offsetCommitCallback printingOffsetCallback)
              <> logLevel KafkaLogInfo
 
@@ -39,12 +39,12 @@ processMessages kafka = do
           ) [0 :: Integer .. 10]
     return $ Right ()
 
-printingRebalanceCallback :: String -> KafkaConsumer -> RebalanceEvent -> IO ()
-printingRebalanceCallback s _ e = case e of
+printingRebalanceCallback :: KafkaConsumer -> RebalanceEvent -> IO ()
+printingRebalanceCallback _ e = case e of
     RebalanceAssign ps ->
-        putStrLn $ s <> "[Rebalance] Assign partitions: " <> show ps
+        putStrLn $ "[Rebalance] Assign partitions: " <> show ps
     RebalanceRevoke ps ->
-        putStrLn $ s <> "[Rebalance] Revoke partitions: " <> show ps
+        putStrLn $ "[Rebalance] Revoke partitions: " <> show ps
 
 printingOffsetCallback :: KafkaConsumer -> KafkaError -> [TopicPartition] -> IO ()
 printingOffsetCallback _ e ps = do

--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -1,5 +1,5 @@
 name:                hw-kafka-client
-version:             2.2.0
+version:             2.3.0
 homepage:            https://github.com/haskell-works/hw-kafka-client
 bug-reports:         https://github.com/haskell-works/hw-kafka-client/issues
 license:             MIT

--- a/src/Kafka/Callbacks.hs
+++ b/src/Kafka/Callbacks.hs
@@ -10,12 +10,10 @@ import Kafka.Types
 
 errorCallback :: HasKafkaConf k => (KafkaError -> String -> IO ()) -> k -> IO ()
 errorCallback callback k =
-  let (KafkaConf c _) = getKafkaConf k
-      realCb _ err = callback (KafkaResponseError err)
-  in rdKafkaConfSetErrorCb c realCb
+  let realCb _ err = callback (KafkaResponseError err)
+  in rdKafkaConfSetErrorCb (getRdKafkaConf k) realCb
 
 logCallback :: HasKafkaConf k => (Int -> String -> String -> IO ()) -> k -> IO ()
 logCallback callback k =
-  let (KafkaConf c _) = getKafkaConf k
-      realCb _ = callback
-  in rdKafkaConfSetLogCb c realCb
+  let realCb _ = callback
+  in rdKafkaConfSetLogCb (getRdKafkaConf k) realCb

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -1,18 +1,19 @@
 module Kafka.Consumer.ConsumerProperties
 ( module Kafka.Consumer.ConsumerProperties
-, module Kafka.Consumer.Callbacks
+, module X
 )
 where
 
 --
 import           Control.Monad
-import qualified Data.List                as L
-import           Data.Map                 (Map)
-import qualified Data.Map                 as M
-import           Kafka.Consumer.Callbacks
+import qualified Data.List            as L
+import           Data.Map             (Map)
+import qualified Data.Map             as M
 import           Kafka.Consumer.Types
 import           Kafka.Internal.Setup
 import           Kafka.Types
+
+import Kafka.Consumer.Callbacks as X
 
 -- | Properties to create 'KafkaConsumer'.
 data ConsumerProperties = ConsumerProperties
@@ -30,7 +31,7 @@ instance Monoid ConsumerProperties where
     }
   {-# INLINE mempty #-}
   mappend (ConsumerProperties m1 ll1 cb1) (ConsumerProperties m2 ll2 cb2) =
-    ConsumerProperties (M.union m2 m1) (ll2 `mplus` ll1) (cb2 `mplus` cb1)
+    ConsumerProperties (M.union m2 m1) (ll2 `mplus` ll1) (cb1 `mplus` cb2)
   {-# INLINE mappend #-}
 
 brokersList :: [BrokerAddress] -> ConsumerProperties

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -28,6 +28,11 @@ newtype ConsumerGroupId = ConsumerGroupId String deriving (Show, Eq)
 newtype Offset          = Offset Int64 deriving (Show, Eq, Read)
 data OffsetReset        = Earliest | Latest deriving (Show, Eq)
 
+data RebalanceEvent =
+    RebalanceAssign [(TopicName, PartitionId)]
+  | RebalanceRevoke [(TopicName, PartitionId)]
+  deriving (Eq, Show)
+
 data PartitionOffset =
     PartitionOffsetBeginning
   | PartitionOffsetEnd

--- a/src/Kafka/Producer.hs
+++ b/src/Kafka/Producer.hs
@@ -56,7 +56,7 @@ runProducer props f =
 -- A newly created producer must be closed with 'closeProducer' function.
 newProducer :: MonadIO m => ProducerProperties -> m (Either KafkaError KafkaProducer)
 newProducer pps = liftIO $ do
-  kc@(KafkaConf kc' _) <- kafkaConf (KafkaProps $ M.toList (ppKafkaProps pps))
+  kc@(KafkaConf kc' _ _) <- kafkaConf (KafkaProps $ M.toList (ppKafkaProps pps))
   tc <- topicConf (TopicProps $ M.toList (ppTopicProps pps))
 
   -- set callbacks
@@ -151,7 +151,7 @@ produceMessageBatch kp@(KafkaProducer (Kafka k) _ (TopicConf tc)) messages = lif
 -- Will wait until the outbound queue is drained before returning the control.
 closeProducer :: MonadIO m => KafkaProducer -> m ()
 closeProducer p =
-  let (KafkaConf _ ct) = kpKafkaConf p
+  let (KafkaConf _ _ ct) = kpKafkaConf p
   in liftIO (CToken.cancel ct) >> flushProducer p
 
 -- | Drains the outbound queue for a producer.

--- a/src/Kafka/Producer/Callbacks.hs
+++ b/src/Kafka/Producer/Callbacks.hs
@@ -15,7 +15,7 @@ import Kafka.Types
 -- | Sets the callback for delivery errors.
 -- The callback is only called in case of errors.
 deliveryErrorsCallback :: (KafkaError -> IO ()) -> KafkaConf -> IO ()
-deliveryErrorsCallback callback (KafkaConf conf _) = rdKafkaConfSetDrMsgCb conf realCb
+deliveryErrorsCallback callback kc = rdKafkaConfSetDrMsgCb (getRdKafkaConf kc) realCb
   where
     realCb :: t -> Ptr RdKafkaMessageT -> IO ()
     realCb _ mptr =

--- a/src/Kafka/Producer/ProducerProperties.hs
+++ b/src/Kafka/Producer/ProducerProperties.hs
@@ -30,7 +30,7 @@ instance Monoid ProducerProperties where
     }
   {-# INLINE mempty #-}
   mappend (ProducerProperties k1 t1 ll1 cb1) (ProducerProperties k2 t2 ll2 cb2) =
-    ProducerProperties (M.union k2 k1) (M.union t2 t1) (ll2 `mplus` ll1) (cb2 `mplus` cb1)
+    ProducerProperties (M.union k2 k1) (M.union t2 t1) (ll2 `mplus` ll1) (cb1 `mplus` cb2)
   {-# INLINE mappend #-}
 
 brokersList :: [BrokerAddress] -> ProducerProperties

--- a/tests-it/Kafka/IntegrationSpec.hs
+++ b/tests-it/Kafka/IntegrationSpec.hs
@@ -107,7 +107,9 @@ spec = do
                 res <- seek k (Timeout 1000) [TopicPartition testTopic (PartitionId 0) PartitionOffsetEnd]
                 res `shouldBe` Nothing
                 msg <- pollMessage k (Timeout 1000)
-                crOffset <$> msg `shouldBe` Left (KafkaResponseError RdKafkaRespErrPartitionEof)
+                crOffset <$> msg `shouldSatisfy` (\x ->
+                        x == Left (KafkaResponseError RdKafkaRespErrPartitionEof)
+                    ||  x == Left (KafkaResponseError RdKafkaRespErrTimedOut))
 
             it "should respect out-of-bound offsets (invalid offset)" $ \k -> do
                 res <- seek k (Timeout 1000) [TopicPartition testTopic (PartitionId 0) PartitionOffsetInvalid]


### PR DESCRIPTION
## Changes
- Separated messages queue from event loop (see below).
- Refactored the rebalance callback to be more precise in types.

## Problem
Although `librdkafka` has different `poll*` functions (`rd_kafka_poll`, `rd_kafka_consumer_poll`), some important callbacks (such as rebalance callback) are dispatched to the _consumer queue_. By default, the consumer queue is the same queue that is used for consuming messages.

Because of that consumer events (such as rebalance callback) are only handled when `rd_kafka_consumer_poll` is called. This means that if message handling takes a long time, the consumer will not handle rebalance callbacks, which can cause different sort of troubles.

Ideally, the consumer should be able to react to rebalance callbacks ASAP. One concrete example of how it may be important is the ability to cancel a long-running operation when rebalance happens in the middle of it.

## Solution
The solution is suggested by the author of `librdkafka`.
Turns out that in `librdkafka` internally each partition has its own _queue_. By default messages from these queues are forwarded to the _consumer queue_, but it can be changed. The proposed solution is to create another kafka queue for messages only and to _forward_ partition queues to this new queue.

This can be done as:
- The queue is created as a part of creating `KafkaConsumer`.
-  In a _rebalance callback_ before confirming assignment each assigned partition queue is forwarded to the new messages queue.
- `pollMessage` is changed to consume messages from the new queue and not from the _consumer queue_.
- Polling the _consumer queue_ is done periodically and asynchronously as it is now only responsible for handling callbacks.

The proposed solution implements this logic.

## Implications
The rebalance callback is not optional now. It must always be there to set up queues forwarding.
This solution makes it looks like it was optional anyway: if a user doesn't set the callback, then the "default" one is used.
The callback logic is refactored, and it looks even better because the internals of `librdkafka` flow are not exposed anymore (e.g. users don't need to know/remember to call `assign` from the rebalance callback).

ping @newhoggy 