### PR TITLE
Fix off-by-one error in per-message commit

### DIFF
--- a/src/Kafka/Consumer.hs
+++ b/src/Kafka/Consumer.hs
@@ -102,7 +102,7 @@ commitOffsetMessage :: MonadIO m
                     -> ConsumerRecord k v
                     -> m (Maybe KafkaError)
 commitOffsetMessage o k m =
-  liftIO $ toNativeTopicPartitionList [topicPartitionFromMessage m] >>= commitOffsets o k
+  liftIO $ toNativeTopicPartitionList [topicPartitionFromMessageForCommit m] >>= commitOffsets o k
 
 -- | Commit offsets for all currently assigned partitions.
 commitAllOffsets :: MonadIO m

--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -95,6 +95,14 @@ topicPartitionFromMessage m =
   let (Offset moff) = crOffset m
    in TopicPartition (crTopic m) (crPartition m) (PartitionOffset moff)
 
+-- | Creates a topic partition message for use with the offset commit message.
+-- We increment the offset by 1 here because when we commit, the offset is the position
+-- the consumer reads from to process the next message.
+topicPartitionFromMessageForCommit :: ConsumerRecord k v -> TopicPartition
+topicPartitionFromMessageForCommit m =
+  let (TopicPartition t p (PartitionOffset moff)) = topicPartitionFromMessage m
+   in TopicPartition t p (PartitionOffset $ moff + 1)
+
 toMap :: Ord k => [(k, v)] -> Map k [v]
 toMap kvs = fromListWith (++) [(k, [v]) | (k, v) <- kvs]
 


### PR DESCRIPTION
To perform an offset commit, we need to send Kafka an offset. That offset refers to the position the consumer should read from to process the next message, *not* the offset of the last processed message.

But currently the `commitOffsetMessage` function just uses the message offset of the message we pass in, which means if we will always reprocess at least one message when reconnecting.

This PR adds a new set of tests, which does the following:

1. Send 2 messages to test topic
2. Receive those messages, and commit each of them using `commitOffsetMessage`
3. Send 2 more messages to test topic
4. Receive those messages, and commit all of them

The commit `5ebf92a` adds just these test cases without the fix; if we checkout this commit and run the tests we will get this output:

```
Kafka.Integration
  Kafka.IntegrationSpec
    Run producer
      sends messages to test topic
    Consumer with per-message commit
      should receive 2 messages
    Run producer again
      sends messages to test topic
    Consumer after per-message commit
      should receive 2 messages again FAILED [1]

...

Failures:

  tests-it/Kafka/IntegrationSpec.hs:48: 
  1) Kafka.Integration.Kafka.IntegrationSpec, Consumer after per-message commit, should receive 2 messages again
       expected: Right 2
        but got: Right 3

```

Even though we called `commitOffsetMessage` for both messages, one of the messages was reprocessed. 

The fix is basically a new version of `topicPartitionFromMessage`, named `topicPartitionFromMessageForCommit`. It returns the topic partition metadata from the passed message, with the offset incremented by 1.

If we checkout the head of this branch and rerun the tests, we get:

```
Kafka.Integration
  Kafka.IntegrationSpec
    Run producer
      sends messages to test topic
    Consumer with per-message commit
      should receive 2 messages
    Run producer again
      sends messages to test topic
    Consumer after per-message commit
      should receive 2 messages again
```

...with no errors.