### PR TITLE
Manual offset storage

### DIFF
--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -108,7 +108,6 @@ test-suite tests
                      , hw-kafka-client
                      , monad-loops
                      , hspec
-                     , regex-posix
                      , either
 
 test-suite integration-tests
@@ -126,5 +125,4 @@ test-suite integration-tests
                      , hw-kafka-client
                      , monad-loops
                      , hspec
-                     , regex-posix
                      , either

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -45,8 +45,8 @@ noAutoCommit =
   extraProps $ M.fromList [("enable.auto.commit", "false")]
 
 -- | Disables auto offset store for the consumer
-noAutoStore :: ConsumerProperties
-noAutoStore =
+noAutoOffsetStore :: ConsumerProperties
+noAutoOffsetStore =
   extraProps $ M.fromList [("enable.auto.offset.store", "false")]
 
 -- | Consumer group id

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -44,6 +44,11 @@ noAutoCommit :: ConsumerProperties
 noAutoCommit =
   extraProps $ M.fromList [("enable.auto.commit", "false")]
 
+-- | Disables auto offset store for the consumer
+noAutoStore :: ConsumerProperties
+noAutoStore =
+  extraProps $ M.fromList [("enable.auto.offset.store", "false")]
+
 -- | Consumer group id
 groupId :: ConsumerGroupId -> ConsumerProperties
 groupId (ConsumerGroupId cid) =

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -855,6 +855,10 @@ rdKafkaConsumeStop topicPtr partition = do
   {`RdKafkaTopicTPtr', cIntConv `CInt32T', cIntConv `CInt64T'}
   -> `RdKafkaRespErrT' cIntToEnum #}
 
+{#fun rd_kafka_offsets_store as rdKafkaOffsetsStore
+  {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'}
+  -> `RdKafkaRespErrT' cIntToEnum #}
+
 -- rd_kafka produce
 
 {#fun rd_kafka_produce as ^

--- a/tests-it/Kafka/TestEnv.hs
+++ b/tests-it/Kafka/TestEnv.hs
@@ -35,7 +35,7 @@ consumerProps broker = C.brokersList [broker]
                     <> noAutoCommit
 
 consumerPropsNoStore :: BrokerAddress -> ConsumerProperties
-consumerPropsNoStore broker = consumerProps broker <> noAutoStore
+consumerPropsNoStore broker = consumerProps broker <> noAutoOffsetStore
 
 producerProps :: BrokerAddress -> ProducerProperties
 producerProps broker = P.brokersList [broker]

--- a/tests-it/Kafka/TestEnv.hs
+++ b/tests-it/Kafka/TestEnv.hs
@@ -34,6 +34,9 @@ consumerProps broker = C.brokersList [broker]
                     <> C.setCallback (errorCallback (\e r -> print $ show e <> ": " <> r))
                     <> noAutoCommit
 
+consumerPropsNoStore :: BrokerAddress -> ConsumerProperties
+consumerPropsNoStore broker = consumerProps broker <> noAutoStore
+
 producerProps :: BrokerAddress -> ProducerProperties
 producerProps broker = P.brokersList [broker]
                     <> P.setCallback (logCallback (\l s1 s2 -> print $ show l <> ": " <> s1 <> ", " <> s2))
@@ -48,13 +51,13 @@ mkProducer = do
     (Right p) <- newProducer (producerProps brokerAddress)
     return p
 
-mkConsumer :: IO KafkaConsumer
-mkConsumer = do
-    (Right c) <- newConsumer (consumerProps brokerAddress) (testSubscription testTopic)
+mkConsumerWith :: (BrokerAddress -> ConsumerProperties) -> IO KafkaConsumer
+mkConsumerWith props = do
+    (Right c) <- newConsumer (props brokerAddress) (testSubscription testTopic)
     return c
 
-specWithConsumer :: String -> SpecWith KafkaConsumer -> Spec
-specWithConsumer s f = beforeAll mkConsumer $ afterAll (void . closeConsumer) $ describe s f
+specWithConsumer :: String -> (BrokerAddress -> ConsumerProperties) -> SpecWith KafkaConsumer -> Spec
+specWithConsumer s p f = beforeAll (mkConsumerWith p) $ afterAll (void . closeConsumer) $ describe s f
 
 specWithProducer :: String -> SpecWith KafkaProducer -> Spec
 specWithProducer s f = beforeAll mkProducer $ afterAll (void . closeProducer) $ describe s f


### PR DESCRIPTION
## The problem

When we turn off automatic offset commits, it's usually because we want to ensure messages are reprocessed in the event of a consumer failure. But this means after we process every message, we have to manually commit to Kafka.

If we use synchronous offset commits, our throughput will take a huge hit, as we incur a roundtrip to the broker for *every* message we process.

And asynchronous offset commits don't solve everything either. If the incoming messages are processed faster than a round trip to the broker, the internal librdkafka request queue will grow unbounded, as there is no backpressure stopping the commit requests from piling up. We will eventually end up with strange timeout errors, etc.

## An alternative
librdkafka maintains an internal local *store* of offsets. By default, librdkakfa will automatically update this local offset store after a message is consumed, and then a separate process will periodically commit the contents of the local store back to Kafka.

Even though we turn off the automatic commits, the local offset store is still automatically updated. So this PR adds a new consumer property `noAutoStore`, which turns off the automatic local offset storage. Then when we finish processing a message, we can manually store the offset (plus 1 as per PR #49) by calling the function `storeOffsetMessage`.

And that frees us to leave the auto commit loop going, without worrying about committing unprocessed messages.

That way, the round trip is amortised over the auto commit interval. And we can get the desired level of durability by changing the auto commit interval, as we should only reprocess up to a commit interval's worth of messages in the event of a consumer crash.

## Tests

This PR adds a new set of tests that configure the broker to not automatically store offsets, and then test the expected things happen when we manually store offsets.
 