### PR TITLE
Fix typo in KafkaError value constructor

### DIFF
--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -67,7 +67,7 @@ data KafkaError =
   | KafkaResponseError RdKafkaRespErrT
   | KafkaInvalidConfigurationValue String
   | KafkaUnknownConfigurationKey String
-  | KakfaBadConfiguration
+  | KafkaBadConfiguration
     deriving (Eq, Show, Typeable)
 
 instance Exception KafkaError


### PR DESCRIPTION
The value constructor `KakfaBadConfiguration` for the type `KafkaError` looks like a typo.  It should be `KafkaBadConfiguration`.  Note that `KakfaBadConfiguration` is not used anywhere else in the repo.