### PR TITLE
pass partition list pointer to librdkafka without recreating the list

### DIFF
--- a/src/Kafka/Consumer/Callbacks.hs
+++ b/src/Kafka/Consumer/Callbacks.hs
@@ -35,7 +35,7 @@ rebalanceCallback callback kc@(KafkaConf conf _ _) = rdKafkaConfSetRebalanceCb c
   where
     realCb k err pl = do
       k' <- newForeignPtr_ k
-      pls <- fromNativeTopicPartitionList' pl
+      pls <- newForeignPtr_ pl
       setRebalanceCallback callback (KafkaConsumer (Kafka k') kc) (KafkaResponseError err) pls
 
 -- | Sets a callback that is called when rebalance is needed.
@@ -67,19 +67,22 @@ redirectPartitionQueue (Kafka k) (TopicName t) (PartitionId p) q = do
 setRebalanceCallback :: (KafkaConsumer -> RebalanceEvent -> IO ())
                           -> KafkaConsumer
                           -> KafkaError
-                          -> [TopicPartition] -> IO ()
-setRebalanceCallback f k e ps =
-  let assignment = (tpTopicName &&& tpPartition) <$> ps
-  in case e of
+                          -> RdKafkaTopicPartitionListTPtr -> IO ()
+setRebalanceCallback f k e pls =
+  case e of
     KafkaResponseError RdKafkaRespErrAssignPartitions -> do
+        ps <- fromNativeTopicPartitionList'' pls
+        let assignment = (tpTopicName &&& tpPartition) <$> ps
         mbq <- getRdMsgQueue $ getKafkaConf k
         case mbq of
           Nothing -> pure ()
           Just mq -> forM_ ps (\tp -> redirectPartitionQueue (getKafka k) (tpTopicName tp) (tpPartition tp) mq)
         f k (RebalanceBeforeAssign assignment)
-        void $ assign k ps
+        void $ assign' k pls
         f k (RebalanceAssign assignment)
     KafkaResponseError RdKafkaRespErrRevokePartitions -> do
+        ps <- fromNativeTopicPartitionList'' pls
+        let assignment = (tpTopicName &&& tpPartition) <$> ps
         f k (RebalanceBeforeRevoke assignment)
         void $ assign k []
         f k (RebalanceRevoke assignment)
@@ -94,3 +97,12 @@ assign (KafkaConsumer (Kafka k) _) ps =
                 else toNativeTopicPartitionList ps
         er = KafkaResponseError <$> (pl >>= rdKafkaAssign k)
     in kafkaErrorToMaybe <$> er
+
+-- | Assigns specified partitions to a current consumer.
+-- Assigning an empty list means unassigning from all partitions that are currently assigned.
+assign' :: KafkaConsumer -> RdKafkaTopicPartitionListTPtr -> IO (Maybe KafkaError)
+assign' (KafkaConsumer (Kafka k) _) pls = do
+    er <- KafkaResponseError <$> rdKafkaAssign k pls
+    -- let m = kafkaErrorToMaybe <$> er
+    return (Just er)
+

--- a/src/Kafka/Consumer/Callbacks.hs
+++ b/src/Kafka/Consumer/Callbacks.hs
@@ -102,7 +102,7 @@ assign (KafkaConsumer (Kafka k) _) ps =
 -- Assigning an empty list means unassigning from all partitions that are currently assigned.
 assign' :: KafkaConsumer -> RdKafkaTopicPartitionListTPtr -> IO (Maybe KafkaError)
 assign' (KafkaConsumer (Kafka k) _) pls = do
-    er <- KafkaResponseError <$> rdKafkaAssign k pls
-    -- let m = kafkaErrorToMaybe <$> er
-    return (Just er)
+    let er = KafkaResponseError <$> rdKafkaAssign k pls
+    m <- kafkaErrorToMaybe <$> er
+    return m
 


### PR DESCRIPTION
Comparing with `rdkafka_consumer_example.c`:

It sets a callback almost the same way we do:

```
                /* Callback called on partition assignment changes */
                rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
```

```
static void rebalance_cb (rd_kafka_t *rk,
                          rd_kafka_resp_err_t err,
			  rd_kafka_topic_partition_list_t *partitions,
                          void *opaque) {
...
		rd_kafka_assign(rk, partitions);
```

Except that they use the `rd_kafka_topic_partition_list_t *` that librdkafka passes to the callback.

We are capturing the partition list pointer in `rebalanceCallback` and converting it to native haskell data, then converting it back to `rd_kafka_topic_partition_list_t *` when assigning partitions:

```
assign :: KafkaConsumer -> [TopicPartition] -> IO (Maybe KafkaError)
assign (KafkaConsumer (Kafka k) _) ps =
    let pl = if null ps
                then newForeignPtr_ nullPtr
                else toNativeTopicPartitionList ps
        er = KafkaResponseError <$> (pl >>= rdKafkaAssign k)
    in kafkaErrorToMaybe <$> er
```

Construction of this looks like:
```
pl <- newRdKafkaTopicPartitionListT
_ <- rdKafkaTopicPartitionListAdd pl tn tp
rdKafkaTopicPartitionListSetOffset pl tn tp to) ps
```

librdkafka itself has `rd_kafka_topic_partition_copy`:
```
void
rd_kafka_topic_partition_copy (rd_kafka_topic_partition_list_t *rktparlist,
                               const rd_kafka_topic_partition_t *rktpar) {
        rd_kafka_topic_partition_t *dst;

        dst = rd_kafka_topic_partition_list_add0(
                rktparlist,
                rktpar->topic,
                rktpar->partition,
                rktpar->_private ?
                rd_kafka_toppar_keep(
                        rd_kafka_toppar_s2i((shptr_rd_kafka_toppar_t *)
                                            rktpar->_private)) : NULL);
        dst->offset = rktpar->offset;
        dst->opaque = rktpar->opaque;
        dst->err    = rktpar->err;
        if (rktpar->metadata_size > 0) {
                dst->metadata =
                        rd_malloc(rktpar->metadata_size);
                dst->metadata_size = rktpar->metadata_size;
                memcpy((void *)dst->metadata, rktpar->metadata,
                       rktpar->metadata_size);
        }
}
```

... which copies significantly more fields across, perhaps important ones.