### PR TITLE
Producer callback also signals success

### DIFF
--- a/example/ProducerExample.hs
+++ b/example/ProducerExample.hs
@@ -13,7 +13,7 @@ import Kafka.Producer
 producerProps :: ProducerProperties
 producerProps = brokersList [BrokerAddress "localhost:9092"]
              <> sendTimeout (Timeout 10000)
-             <> setCallback (deliveryErrorsCallback print)
+             <> setCallback (deliveryCallback print)
              <> logLevel KafkaLogDebug
 
 -- Topic to send messages to

--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -132,24 +132,6 @@ fromMessagePtr ptr =
                 , crValue     = payload
                 }
 
-        readTopic msg = newForeignPtr_ (topic'RdKafkaMessageT msg) >>= rdKafkaTopicName
-        readPayload = readBS len'RdKafkaMessageT payload'RdKafkaMessageT
-        readKey = readBS keyLen'RdKafkaMessageT key'RdKafkaMessageT
-        readTimestamp msg =
-            alloca $ \p -> do
-                typeP <- newForeignPtr_ p
-                ts <- fromIntegral <$> rdKafkaMessageTimestamp msg typeP
-                tsType <- peek p
-                return $ case tsType of
-                    RdKafkaTimestampCreateTime    -> CreateTime (Millis ts)
-                    RdKafkaTimestampLogAppendTime -> LogAppendTime (Millis ts)
-                    RdKafkaTimestampNotAvailable  -> NoTimestamp
-
-        readBS flen fdata s = if fdata s == nullPtr
-                        then return Nothing
-                        else Just <$> word8PtrToBS (flen s) (fdata s)
-
-
 offsetCommitToBool :: OffsetCommit -> Bool
 offsetCommitToBool OffsetCommit      = False
 offsetCommitToBool OffsetCommitAsync = True

--- a/src/Kafka/Producer/Callbacks.hs
+++ b/src/Kafka/Producer/Callbacks.hs
@@ -1,28 +1,56 @@
 module Kafka.Producer.Callbacks
-( deliveryErrorsCallback
+( deliveryCallback
 , module X
 )
 where
 
-import Foreign
-import Foreign.C.Error
-import Kafka.Callbacks        as X
-import Kafka.Internal.RdKafka
-import Kafka.Internal.Setup
-import Kafka.Internal.Shared
-import Kafka.Types
+import           Foreign
+import           Foreign.C.Error
+import           Kafka.Callbacks        as X
+import           Kafka.Consumer.Types
+import           Kafka.Internal.RdKafka
+import           Kafka.Internal.Setup
+import           Kafka.Internal.Shared
+import           Kafka.Producer.Types
+import           Kafka.Types
 
 -- | Sets the callback for delivery errors.
 -- The callback is only called in case of errors.
-deliveryErrorsCallback :: (KafkaError -> IO ()) -> KafkaConf -> IO ()
-deliveryErrorsCallback callback kc = rdKafkaConfSetDrMsgCb (getRdKafkaConf kc) realCb
+deliveryCallback :: (Either ProducerError ProducerSuccess -> IO ()) -> KafkaConf -> IO ()
+deliveryCallback callback kc = rdKafkaConfSetDrMsgCb (getRdKafkaConf kc) realCb
   where
     realCb :: t -> Ptr RdKafkaMessageT -> IO ()
     realCb _ mptr =
       if mptr == nullPtr
-        then getErrno >>= (callback . kafkaRespErr)
+        then getErrno >>= (callback . Left . errNoMessage . kafkaRespErr)
         else do
           s <- peek mptr
           if err'RdKafkaMessageT s /= RdKafkaRespErrNoError
-            then (callback . KafkaResponseError $ err'RdKafkaMessageT s)
-            else pure ()
+            then do
+              r <- mkErrorReport s
+              callback (Left r)
+            else do
+              r <- mkSuccessReport s
+              callback (Right r)
+    errNoMessage ke = ProducerError { peValue = Nothing, peError = ke }
+
+mkErrorReport :: RdKafkaMessageT -> IO ProducerError
+mkErrorReport p = do
+  payload <- readPayload p
+  pure ProducerError
+    { peError = KafkaResponseError (err'RdKafkaMessageT p)
+    , peValue = payload
+    }
+
+mkSuccessReport :: RdKafkaMessageT -> IO ProducerSuccess
+mkSuccessReport msg = do
+  topic     <- readTopic msg
+  key       <- readKey msg
+  payload   <- readPayload msg
+  pure ProducerSuccess
+    { psTopic     = TopicName topic
+    , psPartition = PartitionId $ partition'RdKafkaMessageT msg
+    , psOffset    = Offset $ offset'RdKafkaMessageT msg
+    , psKey       = key
+    , psValue     = payload
+    }

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString      as BS
 import           Data.Typeable
 import           Kafka.Internal.Setup
 import           Kafka.Types
+import Kafka.Consumer.Types
 
 -- | Main pointer to Kafka object, which contains our brokers
 data KafkaProducer = KafkaProducer
@@ -39,3 +40,19 @@ data ProducePartition =
     SpecifiedPartition {-# UNPACK #-} !Int  -- the partition number of the topic
   | UnassignedPartition
   deriving (Show, Eq, Ord, Typeable)
+
+-- | Represents the report of a successfully delivered message.
+data ProducerSuccess = ProducerSuccess
+  { psTopic     :: !TopicName    -- ^ Kafka topic this message was received from
+  , psPartition :: !PartitionId  -- ^ Kafka partition this message was received from
+  , psOffset    :: !Offset       -- ^ Offset within the 'crPartition' Kafka partition
+  , psKey       :: !(Maybe BS.ByteString)
+  , psValue     :: !(Maybe BS.ByteString)
+  }
+  deriving (Eq, Show, Read, Typeable)
+
+-- | Represents the failure to deliver a message.
+data ProducerError = ProducerError
+  { peValue :: !(Maybe BS.ByteString)  -- ^ The message that failed.
+  , peError :: KafkaError              -- ^ The reason for the failure.
+  } deriving (Eq, Show)

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -45,6 +45,7 @@ data DeliveryReport
   = DeliverySuccess ProducerRecord Offset
   | DeliveryFailure ProducerRecord KafkaError
   | NoMessageError KafkaError
+  deriving (Show, Eq)
 
 -- -- | Represents the report of a successfully delivered message.
 -- data ProducerSuccess = ProducerSuccess

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -41,18 +41,23 @@ data ProducePartition =
   | UnassignedPartition
   deriving (Show, Eq, Ord, Typeable)
 
--- | Represents the report of a successfully delivered message.
-data ProducerSuccess = ProducerSuccess
-  { psTopic     :: !TopicName    -- ^ Kafka topic this message was received from
-  , psPartition :: !PartitionId  -- ^ Kafka partition this message was received from
-  , psOffset    :: !Offset       -- ^ Offset within the 'crPartition' Kafka partition
-  , psKey       :: !(Maybe BS.ByteString)
-  , psValue     :: !(Maybe BS.ByteString)
-  }
-  deriving (Eq, Show, Read, Typeable)
+data DeliveryReport
+  = DeliverySuccess ProducerRecord Offset
+  | DeliveryFailure ProducerRecord KafkaError
+  | NoMessageError KafkaError
 
--- | Represents the failure to deliver a message.
-data ProducerError = ProducerError
-  { peValue :: !(Maybe BS.ByteString)  -- ^ The message that failed.
-  , peError :: KafkaError              -- ^ The reason for the failure.
-  } deriving (Eq, Show)
+-- -- | Represents the report of a successfully delivered message.
+-- data ProducerSuccess = ProducerSuccess
+--   { psTopic     :: !TopicName    -- ^ Kafka topic this message was received from
+--   , psPartition :: !PartitionId  -- ^ Kafka partition this message was received from
+--   , psOffset    :: !Offset       -- ^ Offset within the 'crPartition' Kafka partition
+--   , psKey       :: !(Maybe BS.ByteString)
+--   , psValue     :: !(Maybe BS.ByteString)
+--   }
+--   deriving (Eq, Show, Read, Typeable)
+
+-- -- | Represents the failure to deliver a message.
+-- data ProducerError = ProducerError
+--   { peValue :: !(Maybe BS.ByteString)  -- ^ The message that failed.
+--   , peError :: KafkaError              -- ^ The reason for the failure.
+--   } deriving (Eq, Show)


### PR DESCRIPTION
I have patched for my needs but I see what you mean about `ConsumerRecord` now. I've created a very similar type for the producer. I've moved some of the code into `Shared`. Maybe there should be a generic `Message` in `Kafka.Types` (which replaces `ConsumerRecord`)?

Feel free to request changes.