### PR TITLE
fix some issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Icon
 
 ### Haskell ###
 dist
+dist-newstyle
 cabal-dev
 *.o
 *.hi
@@ -34,6 +35,10 @@ cabal.sandbox.config
 cabal.config
 .stack-work/
 *.cabal
+*.ghc*
+
+### Nix ###
+result*
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/build/integration-tests.sh
+++ b/build/integration-tests.sh
@@ -2,5 +2,6 @@
 
 export DOCKER_IP=`ifconfig | grep "inet addr:" | grep "Bcast:0.0.0.0" | cut -d: -f2 | awk '{ print $1}'`
 
-stack clean
-KAFKA_TEST_BROKER=$DOCKER_IP stack test
+KAFKA_TEST_BROKER=$DOCKER_IP
+
+nix-build

--- a/build/integration-tests.sh
+++ b/build/integration-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-export DOCKER_IP=`ifconfig | grep "inet addr:" | grep "Bcast:0.0.0.0" | cut -d: -f2 | awk '{ print $1}'`
-
-KAFKA_TEST_BROKER=$DOCKER_IP
-
-nix-build
+nix-shell --run " export DOCKER_IP=`ifconfig | grep "inet addr:" | grep "Bcast:0.0.0.0" | cut -d: -f2 | awk '{ print $1}'`; \
+                  KAFKA_TEST_BROKER=$DOCKER_IP; \
+                  docker-compose up -d; \
+                  sleep 2; \
+                  nix-build; \
+                "

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ let
 
   haskellPackages = pkgs.haskell.packages.ghc843;
 
-  drv = haskell.lib.dontCheck (haskellPackages.callCabal2nix "hw-kafka-client" ./. {});
+  drv = haskellPackages.callCabal2nix "hw-kafka-client" ./. {};
 
 in
   drv

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,10 @@
-{ nixpkgs ? import <nixpkgs> {} }:
+{ compiler ? "ghc843" }:
 
-let
-  inherit (nixpkgs) pkgs;
-  inherit (pkgs) haskell;
+with rec {
+  pkgs = (import ./nix/nixpkgs.nix {
+    inherit compiler; 
+  });
+  drv = pkgs.haskellPackages.hw-kafka-client;
+};
 
-  haskellPackages = pkgs.haskell.packages.ghc843;
-
-  drv = haskellPackages.callCabal2nix "hw-kafka-client" ./. {};
-
-in
-  drv
+drv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+let
+  inherit (nixpkgs) pkgs;
+  inherit (pkgs) haskell;
+
+  haskellPackages = pkgs.haskell.packages.ghc843;
+
+  drv = haskell.lib.dontCheck (haskellPackages.callCabal2nix "hw-kafka-client" ./. {});
+
+in
+  drv

--- a/example/ConsumerExample.hs
+++ b/example/ConsumerExample.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module ConsumerExample
 
@@ -7,6 +8,7 @@ import Control.Arrow     ((&&&))
 import Control.Exception (bracket)
 import Data.Monoid       ((<>))
 import Kafka.Consumer
+import Data.Text         (Text)
 
 -- Global consumer properties
 consumerProps :: ConsumerProperties

--- a/example/ProducerExample.hs
+++ b/example/ProducerExample.hs
@@ -9,6 +9,7 @@ import Data.ByteString       (ByteString)
 import Data.ByteString.Char8 (pack)
 import Data.Monoid
 import Kafka.Producer
+import Data.Text             (Text)
 
 -- Global producer properties
 producerProps :: ProducerProperties

--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -98,6 +98,7 @@ executable kafka-client-example
     , bytestring
     , containers
     , hw-kafka-client
+    , text
     , transformers
     , unix
   if !(flag(examples))

--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -40,7 +40,12 @@ flag examples
 library
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
   extra-libraries:
       rdkafka
   build-depends:

--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -48,6 +48,7 @@ library
     , bifunctors
     , bytestring
     , containers
+    , text 
     , transformers
     , unix
   build-tools:

--- a/hw-kafka-client.cabal
+++ b/hw-kafka-client.cabal
@@ -118,6 +118,7 @@ test-suite integration-tests
     , hspec
     , hw-kafka-client
     , monad-loops
+    , text
   other-modules:
       Kafka.IntegrationSpec
       Kafka.TestEnv
@@ -138,6 +139,7 @@ test-suite tests
     , either
     , hspec
     , hw-kafka-client
+    , text
     , monad-loops
   other-modules:
       Kafka.Consumer.ConsumerRecordMapSpec

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,8 @@
+{ rev    # The Git revision of nixpkgs to fetch
+, sha256 # The SHA256 hash of the unpacked archive
+}:
+
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+  inherit sha256;
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,24 @@
+{ compiler ? "ghc843" }:
+
+with rec {
+  fetchFromGitHub = (
+    (import <nixpkgs> { config = {}; overlays = []; }).fetchFromGitHub);
+  _nixpkgs = fetchFromGitHub {
+    owner  = "NixOS";
+    repo   = "nixpkgs";
+    rev    = "e0d1c6315aa699cf063af6d3661b91c814686b3c";
+    sha256 = "0ni4klvxygyxq75mr69xrrbg5166fwmq9rm6vc46x2ww6p0kz652";
+  };
+};
+
+import _nixpkgs {
+  config = {
+    packageOverrides = super: let self = super.pkgs; in {
+      haskellPackages = super.haskell.packages.${compiler}.override {
+        overrides = import ./overrides.nix { pkgs = self; };
+      };
+
+    };
+  };
+  overlays = [];
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,13 +1,11 @@
 { compiler ? "ghc843" }:
 
 with rec {
-  fetchFromGitHub = (
-    (import <nixpkgs> { config = {}; overlays = []; }).fetchFromGitHub);
-  _nixpkgs = fetchFromGitHub {
-    owner  = "NixOS";
-    repo   = "nixpkgs";
-    rev    = "e0d1c6315aa699cf063af6d3661b91c814686b3c";
-    sha256 = "0ni4klvxygyxq75mr69xrrbg5166fwmq9rm6vc46x2ww6p0kz652";
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+  _nixpkgs = fetchNixpkgs {
+    rev = "da0c385a691d38b56b17eb18b852c4cec2050c24";
+    sha256 = "0svhqn139cy2nlgv4kqv1bsxza2dcm0yylrhnmanw4p73gv85caf"; 
   };
 };
 

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+
+self: super:
+
+with { inherit (pkgs.stdenv) lib; };
+
+with pkgs.haskell.lib;
+
+{
+  hw-kafka-client = (
+    with rec {
+      hw-kafka-clientSource = pkgs.lib.cleanSource ../.;
+      hw-kafka-clientBasic = self.callCabal2nix "hw-kafka-client" hw-kafka-clientSource {};
+    };
+    overrideCabal hw-kafka-clientBasic (old: {
+      # preConfigure = "sed -i -e /extra-lib-dirs/d -e /include-dirs/d -e /librdkafka/d hw-kafka-client.cabal";
+      configureFlags = "--extra-include-dirs=${pkgs.rdkafka}/include/librdkafka; --extra-include-dirs=${pkgs.rdkafka}/lib";
+    })
+  );
+}

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -13,8 +13,15 @@ with pkgs.haskell.lib;
       hw-kafka-clientBasic = self.callCabal2nix "hw-kafka-client" hw-kafka-clientSource {};
     };
     overrideCabal hw-kafka-clientBasic (old: {
-      # preConfigure = "sed -i -e /extra-lib-dirs/d -e /include-dirs/d -e /librdkafka/d hw-kafka-client.cabal";
-      configureFlags = "--extra-include-dirs=${pkgs.rdkafka}/include/librdkafka; --extra-include-dirs=${pkgs.rdkafka}/lib";
+      enableLibraryProfiling = false;
+      preConfigure = "sed -i -e /extra-lib-dirs/d -e /include-dirs/d -e /librdkafka/d hw-kafka-client.cabal";
+      configureFlags = ''
+        --extra-include-dirs=${pkgs.rdkafka}/include/librdkafka
+        
+        --extra-prog-path=${pkgs.rdkafka}/lib
+
+        --extra-lib-dirs=${pkgs.rdkafka}/lib
+      '';
     })
   );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix {}).env

--- a/src/Kafka/Callbacks.hs
+++ b/src/Kafka/Callbacks.hs
@@ -5,9 +5,9 @@ module Kafka.Callbacks
 )
 where
 
-import Kafka.Internal.RdKafka
-import Kafka.Internal.Setup
-import Kafka.Types
+import Kafka.Internal.RdKafka (rdKafkaConfSetErrorCb, rdKafkaConfSetLogCb, rdKafkaConfSetStatsCb)
+import Kafka.Internal.Setup (HasKafkaConf(..), getRdKafkaConf)
+import Kafka.Types (KafkaError(..))
 
 errorCallback :: HasKafkaConf k => (KafkaError -> String -> IO ()) -> k -> IO ()
 errorCallback callback k =

--- a/src/Kafka/Consumer.hs
+++ b/src/Kafka/Consumer.hs
@@ -18,6 +18,8 @@ module Kafka.Consumer
 )
 where
 
+import           Data.Set                         (Set)
+import qualified Data.Set                         as Set
 import qualified Data.Text                        as Text
 import           Control.Arrow                    ((&&&), left)
 import           Control.Concurrent               (forkIO, rtsSupportsBoundThreads)
@@ -313,10 +315,10 @@ newConsumerConf ConsumerProperties {cpProps = m, cpCallbacks = cbs} = do
 -- any topic name in the topics list that is prefixed with @^@ will
 -- be regex-matched to the full list of topics in the cluster and matching
 -- topics will be added to the subscription list.
-subscribe :: KafkaConsumer -> [TopicName] -> IO (Maybe KafkaError)
+subscribe :: KafkaConsumer -> Set TopicName -> IO (Maybe KafkaError)
 subscribe (KafkaConsumer (Kafka k) _) ts = do
     pl <- newRdKafkaTopicPartitionListT (length ts)
-    mapM_ (\(TopicName t) -> rdKafkaTopicPartitionListAdd pl (Text.unpack t) (-1)) ts
+    mapM_ (\(TopicName t) -> rdKafkaTopicPartitionListAdd pl (Text.unpack t) (-1)) (Set.toList ts)
     res <- KafkaResponseError <$> rdKafkaSubscribe k pl
     return $ kafkaErrorToMaybe res
 

--- a/src/Kafka/Consumer.hs
+++ b/src/Kafka/Consumer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 module Kafka.Consumer
 ( module X
@@ -17,25 +18,71 @@ module Kafka.Consumer
 )
 where
 
-import           Control.Arrow
+import qualified Data.Text                        as Text
+import           Control.Arrow                    ((&&&), left)
 import           Control.Concurrent               (forkIO, rtsSupportsBoundThreads)
-import           Control.Exception
+import           Control.Exception                (bracket)
 import           Control.Monad                    (forM_, void, when)
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except
-import           Data.Bifunctor
+import           Control.Monad.IO.Class           (MonadIO(liftIO))
+import           Control.Monad.Trans.Except       (ExceptT(ExceptT), runExceptT)
+import           Data.Bifunctor                   (first, bimap)
 import qualified Data.ByteString                  as BS
-import           Data.IORef
+import           Data.IORef                       (writeIORef, readIORef)
 import qualified Data.Map                         as M
 import           Data.Maybe                       (fromMaybe)
 import           Data.Monoid                      ((<>))
 import           Foreign                          hiding (void)
 import           Kafka.Consumer.Convert
-import           Kafka.Consumer.Types
+  (fromMessagePtr, toNativeTopicPartitionList, topicPartitionFromMessageForCommit
+  , toNativeTopicPartitionListNoDispose, toNativeTopicPartitionList, fromNativeTopicPartitionList''
+  , toMap, offsetToInt64, toNativeTopicPartitionList', offsetCommitToBool
+  )
+import           Kafka.Consumer.Types (KafkaConsumer(..))
 import           Kafka.Internal.CancellationToken as CToken
 import           Kafka.Internal.RdKafka
+  ( RdKafkaRespErrT(..)
+  , RdKafkaTopicPartitionListTPtr
+  , RdKafkaTypeT(..)
+  , newRdKafkaT
+  , rdKafkaQueueNew
+  , rdKafkaConsumeQueue
+  , rdKafkaPollSetConsumer
+  , rdKafkaSetLogLevel
+  , rdKafkaOffsetsStore
+  , rdKafkaCommit
+  , rdKafkaConfSetDefaultTopicConf
+  , rdKafkaTopicConfDup
+  , rdKafkaSubscribe
+  , rdKafkaTopicPartitionListAdd
+  , newRdKafkaTopicPartitionListT
+  , rdKafkaConsumerClose
+  , rdKafkaQueueDestroy
+  , rdKafkaConsumerPoll
+  , rdKafkaPosition
+  , rdKafkaCommitted
+  , rdKafkaSeek
+  , rdKafkaResumePartitions
+  , rdKafkaPausePartitions
+  , rdKafkaSubscription
+  , rdKafkaAssignment
+  , rdKafkaConsumeBatchQueue
+  , newRdKafkaTopicT
+  )
 import           Kafka.Internal.Setup
+  ( Kafka(..)
+  , KafkaConf(..)
+  , TopicConf(..)
+  , KafkaProps(..)
+  , TopicProps(..)
+  , kafkaConf
+  , topicConf
+  , getRdKafka
+  )
 import           Kafka.Internal.Shared
+  ( kafkaErrorToMaybe
+  , maybeToLeft
+  , rdKafkaErrorToEither
+  )
 
 import Kafka.Consumer.ConsumerProperties as X
 import Kafka.Consumer.Subscription       as X
@@ -67,7 +114,7 @@ newConsumer :: MonadIO m
 newConsumer props (Subscription ts tp) = liftIO $ do
   let cp = setCallback (rebalanceCallback (\_ _ -> return ())) <> props
   kc@(KafkaConf kc' qref ct) <- newConsumerConf cp
-  tp' <- topicConf (TopicProps $ M.toList tp)
+  tp' <- topicConf (TopicProps tp)
   _   <- setDefaultTopicConf kc tp'
   rdk <- newRdKafkaT RdKafkaConsumer kc'
   case rdk of
@@ -179,14 +226,14 @@ subscription (KafkaConsumer (Kafka k) _) = liftIO $ do
 pausePartitions :: MonadIO m => KafkaConsumer -> [(TopicName, PartitionId)] -> m KafkaError
 pausePartitions (KafkaConsumer (Kafka k) _) ps = liftIO $ do
   pl <- newRdKafkaTopicPartitionListT (length ps)
-  mapM_ (\(TopicName topicName, PartitionId partitionId) -> rdKafkaTopicPartitionListAdd pl topicName partitionId) ps
+  mapM_ (\(TopicName topicName, PartitionId partitionId) -> rdKafkaTopicPartitionListAdd pl (Text.unpack topicName) partitionId) ps
   KafkaResponseError <$> rdKafkaPausePartitions k pl
 
 -- | Resumes specified partitions on the current consumer.
 resumePartitions :: MonadIO m => KafkaConsumer -> [(TopicName, PartitionId)] -> m KafkaError
 resumePartitions (KafkaConsumer (Kafka k) _) ps = liftIO $ do
   pl <- newRdKafkaTopicPartitionListT (length ps)
-  mapM_ (\(TopicName topicName, PartitionId partitionId) -> rdKafkaTopicPartitionListAdd pl topicName partitionId) ps
+  mapM_ (\(TopicName topicName, PartitionId partitionId) -> rdKafkaTopicPartitionListAdd pl (Text.unpack topicName) partitionId) ps
   KafkaResponseError <$> rdKafkaResumePartitions k pl
 
 seek :: MonadIO m => KafkaConsumer -> Timeout -> [TopicPartition] -> m (Maybe KafkaError)
@@ -203,8 +250,8 @@ seek (KafkaConsumer (Kafka k) _) (Timeout timeout) tps = liftIO $
 
     topicPair tp = do
       let (TopicName tn) = tpTopicName tp
-      nt <- newRdKafkaTopicT k tn Nothing
-      return $ bimap KafkaError (,tpPartition tp, tpOffset tp) nt
+      nt <- newRdKafkaTopicT k (Text.unpack tn) Nothing
+      return $ bimap KafkaError (,tpPartition tp, tpOffset tp) (first Text.pack nt)
 
 -- | Retrieve committed offsets for topics+partitions.
 committed :: MonadIO m => KafkaConsumer -> Timeout -> [(TopicName, PartitionId)] -> m (Either KafkaError [TopicPartition])
@@ -256,7 +303,7 @@ closeConsumer (KafkaConsumer (Kafka k) (KafkaConf _ qr ct)) = liftIO $ do
 -----------------------------------------------------------------------------
 newConsumerConf :: ConsumerProperties -> IO KafkaConf
 newConsumerConf ConsumerProperties {cpProps = m, cpCallbacks = cbs} = do
-  conf <- kafkaConf (KafkaProps $ M.toList m)
+  conf <- kafkaConf (KafkaProps m)
   forM_ cbs (\setCb -> setCb conf)
   return conf
 
@@ -269,7 +316,7 @@ newConsumerConf ConsumerProperties {cpProps = m, cpCallbacks = cbs} = do
 subscribe :: KafkaConsumer -> [TopicName] -> IO (Maybe KafkaError)
 subscribe (KafkaConsumer (Kafka k) _) ts = do
     pl <- newRdKafkaTopicPartitionListT (length ts)
-    mapM_ (\(TopicName t) -> rdKafkaTopicPartitionListAdd pl t (-1)) ts
+    mapM_ (\(TopicName t) -> rdKafkaTopicPartitionListAdd pl (Text.unpack t) (-1)) ts
     res <- KafkaResponseError <$> rdKafkaSubscribe k pl
     return $ kafkaErrorToMaybe res
 

--- a/src/Kafka/Consumer/Callbacks.hs
+++ b/src/Kafka/Consumer/Callbacks.hs
@@ -17,6 +17,7 @@ import Kafka.Internal.RdKafka
 import Kafka.Internal.Setup
 import Kafka.Internal.Shared
 import Kafka.Types
+import qualified Data.Text as Text
 
 import Control.Concurrent (threadDelay)
 
@@ -62,7 +63,7 @@ offsetCommitCallback callback kc@(KafkaConf conf _ _) = rdKafkaConfSetOffsetComm
 -------------------------------------------------------------------------------
 redirectPartitionQueue :: Kafka -> TopicName -> PartitionId -> RdKafkaQueueTPtr -> IO ()
 redirectPartitionQueue (Kafka k) (TopicName t) (PartitionId p) q = do
-  mpq <- rdKafkaQueueGetPartition k t p
+  mpq <- rdKafkaQueueGetPartition k (Text.unpack t) p
   case mpq of
     Nothing -> return ()
     Just pq -> rdKafkaQueueForward pq q

--- a/src/Kafka/Consumer/Callbacks.hs
+++ b/src/Kafka/Consumer/Callbacks.hs
@@ -6,20 +6,20 @@ module Kafka.Consumer.Callbacks
 )
 where
 
-import Control.Arrow          ((&&&))
-import Control.Monad          (forM_, void)
-import Data.Monoid            ((<>))
-import Foreign                hiding (void)
-import Kafka.Callbacks        as X
-import Kafka.Consumer.Convert
-import Kafka.Consumer.Types
-import Kafka.Internal.RdKafka
-import Kafka.Internal.Setup
-import Kafka.Internal.Shared
-import Kafka.Types
-import qualified Data.Text as Text
-
-import Control.Concurrent (threadDelay)
+import           Control.Arrow          ((&&&))
+import           Control.Concurrent     (threadDelay)
+import           Control.Monad          (forM_, void)
+import           Data.Monoid            ((<>))
+import qualified Data.Text              as Text
+import           Foreign.ForeignPtr     (newForeignPtr_)
+import           Foreign.Ptr            (nullPtr)
+import           Kafka.Callbacks        as X
+import           Kafka.Consumer.Convert (fromNativeTopicPartitionList', fromNativeTopicPartitionList'', toNativeTopicPartitionList)
+import           Kafka.Consumer.Types   (KafkaConsumer(..), TopicPartition(..), RebalanceEvent(..))
+import           Kafka.Internal.RdKafka
+import           Kafka.Internal.Setup   (Kafka(..), KafkaConf(..), HasKafka(..), HasKafkaConf(..), getRdMsgQueue)
+import           Kafka.Internal.Shared  (kafkaErrorToMaybe)
+import           Kafka.Types            (KafkaError(..), PartitionId(..), TopicName(..))
 
 -- | Sets a callback that is called when rebalance is needed.
 --

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -1,21 +1,33 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Kafka.Consumer.ConsumerProperties
-( module Kafka.Consumer.ConsumerProperties
+( ConsumerProperties(..)
+, brokersList
+, noAutoCommit
+, noAutoOffsetStore
+, groupId
+, clientId
+, setCallback
+, logLevel
+, compression
+, suppressDisconnectLogs
+, extraProps
+, extraProp
+, debugOptions
+, queuedMaxMessagesKBytes
 , module X
 )
 where
 
---
-import           Control.Monad
+import           Control.Monad        (MonadPlus(mplus))
 import           Data.Map             (Map)
 import qualified Data.Map             as M
 import           Data.Semigroup       as Sem
-import           Kafka.Consumer.Types
-import           Kafka.Internal.Setup
-import           Kafka.Types
-import qualified Data.Text as Text
-import Data.Text (Text)
+import           Data.Text            (Text)
+import qualified Data.Text            as Text
+import           Kafka.Consumer.Types (ConsumerGroupId(..))
+import           Kafka.Internal.Setup (KafkaConf(..))
+import           Kafka.Types          (KafkaDebug(..), KafkaCompressionCodec(..), KafkaLogLevel(..), ClientId(..), BrokerAddress(..), kafkaDebugToText, kafkaCompressionCodecToText)
 
 import Kafka.Consumer.Callbacks as X
 

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Kafka.Consumer.ConsumerProperties
 ( module Kafka.Consumer.ConsumerProperties
 , module X
@@ -6,19 +8,20 @@ where
 
 --
 import           Control.Monad
-import qualified Data.List            as L
 import           Data.Map             (Map)
 import qualified Data.Map             as M
 import           Data.Semigroup       as Sem
 import           Kafka.Consumer.Types
 import           Kafka.Internal.Setup
 import           Kafka.Types
+import qualified Data.Text as Text
+import Data.Text (Text)
 
 import Kafka.Consumer.Callbacks as X
 
 -- | Properties to create 'KafkaConsumer'.
 data ConsumerProperties = ConsumerProperties
-  { cpProps     :: Map String String
+  { cpProps     :: Map Text Text
   , cpLogLevel  :: Maybe KafkaLogLevel
   , cpCallbacks :: [KafkaConf -> IO ()]
   }
@@ -41,7 +44,7 @@ instance Monoid ConsumerProperties where
 
 brokersList :: [BrokerAddress] -> ConsumerProperties
 brokersList bs =
-  let bs' = L.intercalate "," ((\(BrokerAddress x) -> x) <$> bs)
+  let bs' = Text.intercalate "," ((\(BrokerAddress x) -> x) <$> bs)
    in extraProps $ M.fromList [("bootstrap.servers", bs')]
 
 -- | Disables auto commit for the consumer
@@ -74,7 +77,7 @@ logLevel ll = mempty { cpLogLevel = Just ll }
 -- | Sets the compression codec for the consumer.
 compression :: KafkaCompressionCodec -> ConsumerProperties
 compression c =
-  extraProps $ M.singleton "compression.codec" (kafkaCompressionCodecToString c)
+  extraProps $ M.singleton "compression.codec" (kafkaCompressionCodecToText c)
 
 -- | Suppresses consumer disconnects logs.
 --
@@ -86,13 +89,13 @@ suppressDisconnectLogs =
 
 -- | Any configuration options that are supported by /librdkafka/.
 -- The full list can be found <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md here>
-extraProps :: Map String String -> ConsumerProperties
+extraProps :: Map Text Text -> ConsumerProperties
 extraProps m = mempty { cpProps = m }
 {-# INLINE extraProps #-}
 
 -- | Any configuration options that are supported by /librdkafka/.
 -- The full list can be found <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md here>
-extraProp :: String -> String -> ConsumerProperties
+extraProp :: Text -> Text -> ConsumerProperties
 extraProp k v = mempty { cpProps = M.singleton k v }
 {-# INLINE extraProp #-}
 
@@ -101,10 +104,10 @@ extraProp k v = mempty { cpProps = M.singleton k v }
 debugOptions :: [KafkaDebug] -> ConsumerProperties
 debugOptions [] = extraProps M.empty
 debugOptions d =
-  let points = L.intercalate "," (kafkaDebugToString <$> d)
+  let points = Text.intercalate "," (kafkaDebugToText <$> d)
    in extraProps $ M.fromList [("debug", points)]
 
 queuedMaxMessagesKBytes :: Int -> ConsumerProperties
 queuedMaxMessagesKBytes kBytes =
-  extraProp "queued.max.messages.kbytes" (show kBytes)
+  extraProp "queued.max.messages.kbytes" (Text.pack $ show kBytes)
 {-# INLINE queuedMaxMessagesKBytes #-}

--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -1,5 +1,19 @@
 module Kafka.Consumer.Convert
-
+( offsetSyncToInt
+, offsetToInt64
+, int64ToOffset
+, fromNativeTopicPartitionList''
+, fromNativeTopicPartitionList'
+, fromNativeTopicPartitionList
+, toNativeTopicPartitionList
+, toNativeTopicPartitionListNoDispose
+, toNativeTopicPartitionList'
+, topicPartitionFromMessage
+, topicPartitionFromMessageForCommit
+, toMap
+, fromMessagePtr
+, offsetCommitToBool
+)
 where
 
 import qualified Data.Text as Text

--- a/src/Kafka/Consumer/Convert.hs
+++ b/src/Kafka/Consumer/Convert.hs
@@ -2,13 +2,13 @@ module Kafka.Consumer.Convert
 
 where
 
+import qualified Data.Text as Text
 import           Control.Monad
 import qualified Data.ByteString        as BS
 import           Data.Map.Strict        (Map, fromListWith)
 import qualified Data.Set               as S
 import           Foreign
 import           Foreign.C.Error
-import           Foreign.C.String
 import           Kafka.Consumer.Types
 import           Kafka.Internal.RdKafka
 import           Kafka.Internal.Shared
@@ -65,7 +65,7 @@ fromNativeTopicPartitionList pl =
     where
         toPart :: RdKafkaTopicPartitionT -> IO TopicPartition
         toPart p = do
-            topic <- peekCString $ topic'RdKafkaTopicPartitionT p
+            topic <- peekCText $ topic'RdKafkaTopicPartitionT p
             return TopicPartition {
                 tpTopicName = TopicName topic,
                 tpPartition = PartitionId $ partition'RdKafkaTopicPartitionT p,
@@ -79,8 +79,9 @@ toNativeTopicPartitionList ps = do
         let TopicName tn = tpTopicName p
             (PartitionId tp) = tpPartition p
             to = offsetToInt64 $ tpOffset p
-        _ <- rdKafkaTopicPartitionListAdd pl tn tp
-        rdKafkaTopicPartitionListSetOffset pl tn tp to) ps
+            tnS = Text.unpack tn 
+        _ <- rdKafkaTopicPartitionListAdd pl tnS tp
+        rdKafkaTopicPartitionListSetOffset pl tnS tp to) ps
     return pl
 
 toNativeTopicPartitionListNoDispose :: [TopicPartition] -> IO RdKafkaTopicPartitionListTPtr
@@ -90,15 +91,16 @@ toNativeTopicPartitionListNoDispose ps = do
         let TopicName tn = tpTopicName p
             (PartitionId tp) = tpPartition p
             to = offsetToInt64 $ tpOffset p
-        _ <- rdKafkaTopicPartitionListAdd pl tn tp
-        rdKafkaTopicPartitionListSetOffset pl tn tp to) ps
+            tnS = Text.unpack tn 
+        _ <- rdKafkaTopicPartitionListAdd pl tnS tp
+        rdKafkaTopicPartitionListSetOffset pl tnS tp to) ps
     return pl
 
 toNativeTopicPartitionList' :: [(TopicName, PartitionId)] -> IO RdKafkaTopicPartitionListTPtr
 toNativeTopicPartitionList' tps = do
     let utps = S.toList . S.fromList $ tps
     pl <- newRdKafkaTopicPartitionListT (length utps)
-    mapM_ (\(TopicName t, PartitionId p) -> rdKafkaTopicPartitionListAdd pl t p) utps
+    mapM_ (\(TopicName t, PartitionId p) -> rdKafkaTopicPartitionListAdd pl (Text.unpack t) p) utps
     return pl
 
 topicPartitionFromMessage :: ConsumerRecord k v -> TopicPartition

--- a/src/Kafka/Consumer/Subscription.hs
+++ b/src/Kafka/Consumer/Subscription.hs
@@ -5,44 +5,45 @@ where
 
 import qualified Data.Text            as Text
 import           Data.Text            (Text)
-import qualified Data.List            as L
 import           Data.Map             (Map)
 import qualified Data.Map             as M
 import           Data.Semigroup       as Sem
 import           Kafka.Consumer.Types
 import           Kafka.Types
+import           Data.Set             (Set)
+import qualified Data.Set             as Set
 
-data Subscription = Subscription [TopicName] (Map Text Text)
+data Subscription = Subscription (Set TopicName) (Map Text Text)
 
 instance Sem.Semigroup Subscription where
   (Subscription ts1 m1) <> (Subscription ts2 m2) =
-    let ts' = L.nub $ L.union ts1 ts2
+    let ts' = Set.union ts1 ts2
         ps' = M.union m1 m2
      in Subscription ts' ps'
   {-# INLINE (<>) #-}
 
 instance Monoid Subscription where
-  mempty = Subscription [] M.empty
+  mempty = Subscription Set.empty M.empty
   {-# INLINE mempty #-}
   mappend = (Sem.<>)
   {-# INLINE mappend #-}
 
 topics :: [TopicName] -> Subscription
-topics ts = Subscription (L.nub ts) M.empty
+topics ts = Subscription (Set.fromList ts) M.empty
 
 offsetReset :: OffsetReset -> Subscription
 offsetReset o =
   let o' = case o of
              Earliest -> "earliest"
              Latest   -> "latest"
-   in Subscription [] (M.fromList [("auto.offset.reset", o')])
+   in Subscription (Set.empty) (M.fromList [("auto.offset.reset", o')])
 
 autoCommit :: Millis -> Subscription
-autoCommit (Millis ms) = Subscription [] $
+autoCommit (Millis ms) = Subscription (Set.empty) $
   M.fromList
     [ ("enable.auto.commit", "true")
     , ("auto.commit.interval.ms", Text.pack $ show ms)
     ]
 
 extraSubscriptionProps :: Map Text Text -> Subscription
-extraSubscriptionProps = Subscription []
+extraSubscriptionProps = Subscription (Set.empty)

--- a/src/Kafka/Consumer/Subscription.hs
+++ b/src/Kafka/Consumer/Subscription.hs
@@ -14,8 +14,8 @@ import           Data.Text            (Text)
 import           Data.Map             (Map)
 import qualified Data.Map             as M
 import           Data.Semigroup       as Sem
-import           Kafka.Consumer.Types
-import           Kafka.Types
+import           Kafka.Consumer.Types (OffsetReset(..))
+import           Kafka.Types          (TopicName(..), Millis(..))
 import           Data.Set             (Set)
 import qualified Data.Set             as Set
 

--- a/src/Kafka/Consumer/Subscription.hs
+++ b/src/Kafka/Consumer/Subscription.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Kafka.Consumer.Subscription
 where
 
+import qualified Data.Text            as Text
+import           Data.Text            (Text)
 import qualified Data.List            as L
 import           Data.Map             (Map)
 import qualified Data.Map             as M
@@ -8,7 +12,7 @@ import           Data.Semigroup       as Sem
 import           Kafka.Consumer.Types
 import           Kafka.Types
 
-data Subscription = Subscription [TopicName] (Map String String)
+data Subscription = Subscription [TopicName] (Map Text Text)
 
 instance Sem.Semigroup Subscription where
   (Subscription ts1 m1) <> (Subscription ts2 m2) =
@@ -37,8 +41,8 @@ autoCommit :: Millis -> Subscription
 autoCommit (Millis ms) = Subscription [] $
   M.fromList
     [ ("enable.auto.commit", "true")
-    , ("auto.commit.interval.ms", show ms)
+    , ("auto.commit.interval.ms", Text.pack $ show ms)
     ]
 
-extraSubscriptionProps :: Map String String -> Subscription
+extraSubscriptionProps :: Map Text Text -> Subscription
 extraSubscriptionProps = Subscription []

--- a/src/Kafka/Consumer/Subscription.hs
+++ b/src/Kafka/Consumer/Subscription.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Kafka.Consumer.Subscription
+( Subscription(..)
+, topics
+, offsetReset
+, autoCommit
+, extraSubscriptionProps
+)
 where
 
 import qualified Data.Text            as Text

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -25,14 +25,14 @@ module Kafka.Consumer.Types
 )
 where
 
-import Data.Text (Text)
-import Data.Bifoldable
-import Data.Bifunctor
-import Data.Bitraversable
-import Data.Int
-import Data.Typeable
-import Kafka.Internal.Setup
-import Kafka.Types
+import Data.Text            (Text)
+import Data.Bifoldable      (Bifoldable(..))
+import Data.Bifunctor       (Bifunctor(..))
+import Data.Bitraversable   (Bitraversable(..), bimapM, bisequenceA)
+import Data.Int             (Int64)
+import Data.Typeable        (Typeable)
+import Kafka.Internal.Setup (HasKafka(..), HasKafkaConf(..), Kafka(..), KafkaConf(..))
+import Kafka.Types          (TopicName(..), PartitionId(..), Millis(..))
 
 data KafkaConsumer = KafkaConsumer
   { kcKafkaPtr  :: !Kafka

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -3,6 +3,7 @@ module Kafka.Consumer.Types
 
 where
 
+import Data.Text (Text)
 import Data.Bifoldable
 import Data.Bifunctor
 import Data.Bitraversable
@@ -24,7 +25,7 @@ instance HasKafkaConf KafkaConsumer where
   getKafkaConf = kcKafkaConf
   {-# INLINE getKafkaConf #-}
 
-newtype ConsumerGroupId = ConsumerGroupId { unConsumerGroupId :: String} deriving (Show, Ord, Eq)
+newtype ConsumerGroupId = ConsumerGroupId { unConsumerGroupId :: Text } deriving (Show, Ord, Eq)
 newtype Offset          = Offset { unOffset :: Int64 } deriving (Show, Eq, Ord, Read)
 data OffsetReset        = Earliest | Latest deriving (Show, Eq)
 

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -1,6 +1,28 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Kafka.Consumer.Types
-
+( KafkaConsumer(..)
+, ConsumerGroupId(..)
+, Offset(..)
+, OffsetReset(..)
+, RebalanceEvent(..)
+, PartitionOffset(..)
+, SubscribedPartitions(..)
+, Timestamp(..)
+, OffsetCommit(..)
+, OffsetStoreSync(..)
+, OffsetStoreMethod(..)
+, TopicPartition(..)
+, ConsumerRecord(..)
+, crMapKey
+, crMapValue
+, crMapKV
+-- why are these here?
+, sequenceFirst
+, traverseFirst
+, traverseFirstM
+, traverseM
+, bitraverseM
+)
 where
 
 import Data.Text (Text)
@@ -82,7 +104,8 @@ data OffsetStoreMethod =
 data TopicPartition = TopicPartition
   { tpTopicName :: TopicName
   , tpPartition :: PartitionId
-  , tpOffset    :: PartitionOffset } deriving (Show, Eq)
+  , tpOffset    :: PartitionOffset
+  } deriving (Show, Eq)
 
 -- | Represents a /received/ message from Kafka (i.e. used in a consumer)
 data ConsumerRecord k v = ConsumerRecord

--- a/src/Kafka/Dump.hs
+++ b/src/Kafka/Dump.hs
@@ -6,17 +6,33 @@ module Kafka.Dump
 )
 where
 
---
 import Kafka.Internal.RdKafka
+  ( CSizePtr
+  , rdKafkaConfDumpFree
+  , peekCText
+  , rdKafkaConfDump
+  , rdKafkaTopicConfDump
+  , rdKafkaDump
+  , handleToCFile
+  , rdKafkaConfPropertiesShow
+  )
 import Kafka.Internal.Setup
+  ( HasKafka(..)
+  , HasTopicConf(..)
+  , HasKafkaConf(..)
+  , getRdKafka
+  , getRdTopicConf
+  , getRdKafkaConf
+  )
 
-import           Control.Monad
-import           Control.Monad.IO.Class
+import           Control.Monad          ((<=<))
+import           Control.Monad.IO.Class (MonadIO(liftIO))
 import           Data.Map.Strict        (Map)
 import qualified Data.Map.Strict        as Map
-import           Foreign
-import           Foreign.C.String
-import           System.IO
+import           Foreign                (Ptr, alloca, Storable(peek, peekElemOff))
+import           Foreign.C.String       (CString)
+import           System.IO              (Handle)
+import           Data.Text              (Text)
 
 -- | Prints out all supported Kafka conf properties to a handle
 hPrintSupportedKafkaConf :: MonadIO m => Handle -> m ()
@@ -27,25 +43,25 @@ hPrintKafka :: (MonadIO m, HasKafka k) => Handle -> k -> m ()
 hPrintKafka h k = liftIO $ handleToCFile h "w" >>= \f -> rdKafkaDump f (getRdKafka k)
 
 -- | Returns a map of the current topic configuration
-dumpTopicConf :: (MonadIO m, HasTopicConf t) => t -> m (Map String String)
+dumpTopicConf :: (MonadIO m, HasTopicConf t) => t -> m (Map Text Text)
 dumpTopicConf t = liftIO $ parseDump (rdKafkaTopicConfDump (getRdTopicConf t))
 
 -- | Returns a map of the current kafka configuration
-dumpKafkaConf :: (MonadIO m, HasKafkaConf k) => k -> m (Map String String)
+dumpKafkaConf :: (MonadIO m, HasKafkaConf k) => k -> m (Map Text Text)
 dumpKafkaConf k = liftIO $ parseDump (rdKafkaConfDump (getRdKafkaConf k))
 
-parseDump :: (CSizePtr -> IO (Ptr CString)) -> IO (Map String String)
+parseDump :: (CSizePtr -> IO (Ptr CString)) -> IO (Map Text Text)
 parseDump cstr = alloca $ \sizeptr -> do
     strPtr <- cstr sizeptr
     size <- peek sizeptr
 
-    keysAndValues <- mapM (peekCString <=< peekElemOff strPtr) [0..(fromIntegral size - 1)]
+    keysAndValues <- mapM (peekCText <=< peekElemOff strPtr) [0..(fromIntegral size - 1)]
 
     let ret = Map.fromList $ listToTuple keysAndValues
     rdKafkaConfDumpFree strPtr size
     return ret
 
-listToTuple :: [String] -> [(String, String)]
-listToTuple []      = []
-listToTuple (k:v:t) = (k, v) : listToTuple t
-listToTuple _       = error "list to tuple can only be called on even length lists"
+listToTuple :: [Text] -> [(Text, Text)]
+listToTuple []       = []
+listToTuple (k:v:ts) = (k, v) : listToTuple ts
+listToTuple _        = error "list to tuple can only be called on even length lists"

--- a/src/Kafka/Internal/CancellationToken.hs
+++ b/src/Kafka/Internal/CancellationToken.hs
@@ -1,7 +1,13 @@
 module Kafka.Internal.CancellationToken
+( CancellationStatus(..)
+, CancellationToken(..)
+, newCancellationToken
+, status
+, cancel
+)
 where
 
-import Data.IORef
+import Data.IORef (IORef, newIORef, readIORef, atomicWriteIORef)
 
 data CancellationStatus = Cancelled | Running deriving (Show, Eq)
 newtype CancellationToken = CancellationToken (IORef CancellationStatus)

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -7,7 +7,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Control.Monad
 import Data.Word
-import Foreign
+import Foreign -- hiding (newForeignPtr)
+-- import Foreign.Concurrent (newForeignPtr)
 import Foreign.C.Error
 import Foreign.C.String
 import Foreign.C.Types

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -7,8 +7,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Control.Monad
 import Data.Word
-import Foreign -- hiding (newForeignPtr)
--- import Foreign.Concurrent (newForeignPtr)
+import Foreign
 import Foreign.C.Error
 import Foreign.C.String
 import Foreign.C.Types

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -5,15 +5,20 @@ module Kafka.Internal.RdKafka where
 
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Control.Monad
-import Data.Word
-import Foreign
-import Foreign.C.Error
-import Foreign.C.String
-import Foreign.C.Types
-import System.IO
-import System.Posix.IO
-import System.Posix.Types
+import Control.Monad (liftM)
+import Data.Int (Int32, Int64)
+import Data.Word (Word8)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Marshal.Array (peekArray, allocaArray)
+import Foreign.Storable (Storable(..))
+import Foreign.Ptr (Ptr, FunPtr, castPtr, nullPtr)
+import Foreign.ForeignPtr (FinalizerPtr, addForeignPtrFinalizer, withForeignPtr, newForeignPtr, newForeignPtr_)
+import Foreign.C.Error (Errno(..), getErrno)
+import Foreign.C.String (CString, newCString, withCAString, peekCAString, peekCAStringLen, peekCString)
+import Foreign.C.Types (CFile, CInt(..), CSize, CChar)
+import System.IO (Handle, stdin, stdout, stderr)
+import System.Posix.IO (handleToFd)
+import System.Posix.Types (Fd(..))
 
 #include <librdkafka/rdkafka.h>
 

--- a/src/Kafka/Internal/Setup.hs
+++ b/src/Kafka/Internal/Setup.hs
@@ -1,4 +1,22 @@
-module Kafka.Internal.Setup where
+module Kafka.Internal.Setup
+( HasKafka(..)
+, HasKafkaConf(..)
+, HasTopicConf(..)
+, getRdKafka
+, getRdKafkaConf
+, getRdMsgQueue
+, getRdTopicConf
+, newTopicConf
+, newKafkaConf
+, kafkaConf
+, topicConf
+, checkConfSetValue
+, setKafkaConfValue
+, setAllKafkaConfValues
+, setTopicConfValue
+, setAllTopicConfValues
+)
+where
 
 import Kafka.Internal.RdKafka
 import Kafka.Types

--- a/src/Kafka/Internal/Setup.hs
+++ b/src/Kafka/Internal/Setup.hs
@@ -1,5 +1,10 @@
 module Kafka.Internal.Setup
-( HasKafka(..)
+( KafkaProps(..)
+, TopicProps(..)
+, Kafka(..)
+, KafkaConf(..)
+, TopicConf(..)
+, HasKafka(..)
 , HasKafkaConf(..)
 , HasTopicConf(..)
 , getRdKafka
@@ -18,14 +23,14 @@ module Kafka.Internal.Setup
 )
 where
 
-import Kafka.Internal.RdKafka
-import Kafka.Types
+import Kafka.Internal.RdKafka (RdKafkaConfResT(..), CCharBufPointer, RdKafkaQueueTPtr, RdKafkaTPtr, RdKafkaConfTPtr, RdKafkaTopicConfTPtr, nErrorBytes, rdKafkaTopicConfSet, newRdKafkaTopicConfT, newRdKafkaConfT, rdKafkaConfSet)
+import Kafka.Types (KafkaError(..))
 
-import Control.Exception
-import Data.IORef
-import Foreign
-import Foreign.C.String
-import Kafka.Internal.CancellationToken
+import Control.Exception (throw)
+import Data.IORef (IORef, newIORef, readIORef)
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.C.String (peekCString)
+import Kafka.Internal.CancellationToken (CancellationToken(..), newCancellationToken)
 import qualified Data.Text as Text
 import Data.Map (Map)
 import Data.Text (Text)

--- a/src/Kafka/Internal/Shared.hs
+++ b/src/Kafka/Internal/Shared.hs
@@ -17,20 +17,24 @@ module Kafka.Internal.Shared
 )
 where
 
-import           Data.Text (Text)
+import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
 import           Control.Concurrent               (forkIO, rtsSupportsBoundThreads)
-import           Control.Exception
+import           Control.Exception                (throw)
 import           Control.Monad                    (void, when)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Internal         as BSI
-import           Foreign                          hiding (void)
-import           Foreign.C.Error
-import           Kafka.Consumer.Types
+import           Data.Word                        (Word8)
+import           Foreign.Ptr                      (Ptr, nullPtr)
+import           Foreign.Marshal.Alloc            (alloca)
+import           Foreign.ForeignPtr               (newForeignPtr_)
+import           Foreign.Storable                 (Storable(peek))
+import           Foreign.C.Error                  (Errno(..))
+import           Kafka.Consumer.Types             (Timestamp(..))
 import           Kafka.Internal.CancellationToken as CToken
-import           Kafka.Internal.RdKafka
-import           Kafka.Internal.Setup
-import           Kafka.Types
+import           Kafka.Internal.RdKafka           (RdKafkaTimestampTypeT(..), RdKafkaMessageTPtr, RdKafkaMessageT(..), RdKafkaRespErrT(..), Word8Ptr, rdKafkaPoll, rdKafkaErrno2err, rdKafkaTopicName, rdKafkaMessageTimestamp)
+import           Kafka.Internal.Setup             (HasKafka(..), Kafka(..))
+import           Kafka.Types                      (KafkaError(..), Timeout(..), Millis(..))
 
 runEventLoop :: HasKafka a => a -> CancellationToken -> Maybe Timeout -> IO ()
 runEventLoop k ct timeout =

--- a/src/Kafka/Internal/Shared.hs
+++ b/src/Kafka/Internal/Shared.hs
@@ -1,6 +1,8 @@
 module Kafka.Internal.Shared
 where
 
+import           Data.Text (Text)
+import qualified Data.Text                        as Text
 import           Control.Concurrent               (forkIO, rtsSupportsBoundThreads)
 import           Control.Exception
 import           Control.Monad                    (void, when)
@@ -38,7 +40,7 @@ kafkaRespErr :: Errno -> KafkaError
 kafkaRespErr (Errno num) = KafkaResponseError $ rdKafkaErrno2err (fromIntegral num)
 {-# INLINE kafkaRespErr #-}
 
-throwOnError :: IO (Maybe String) -> IO ()
+throwOnError :: IO (Maybe Text) -> IO ()
 throwOnError action = do
     m <- action
     case m of
@@ -76,8 +78,8 @@ maybeToLeft = maybe (Right ()) Left
 readPayload :: RdKafkaMessageT -> IO (Maybe BS.ByteString)
 readPayload = readBS len'RdKafkaMessageT payload'RdKafkaMessageT
 
-readTopic :: RdKafkaMessageT -> IO String
-readTopic msg = newForeignPtr_ (topic'RdKafkaMessageT msg) >>= rdKafkaTopicName
+readTopic :: RdKafkaMessageT -> IO Text
+readTopic msg = newForeignPtr_ (topic'RdKafkaMessageT msg) >>= (fmap Text.pack . rdKafkaTopicName)
 
 readKey :: RdKafkaMessageT -> IO (Maybe BSI.ByteString)
 readKey = readBS keyLen'RdKafkaMessageT key'RdKafkaMessageT

--- a/src/Kafka/Internal/Shared.hs
+++ b/src/Kafka/Internal/Shared.hs
@@ -1,4 +1,20 @@
 module Kafka.Internal.Shared
+( runEventLoop
+, pollEvents
+, word8PtrToBS
+, kafkaRespErr
+, throwOnError
+, hasError
+, rdKafkaErrorToEither
+, kafkaErrorToEither
+, kafkaErrorToMaybe
+, maybeToLeft
+, readPayload
+, readTopic
+, readKey
+, readTimestamp
+, readBS
+)
 where
 
 import           Data.Text (Text)

--- a/src/Kafka/Metadata.hs
+++ b/src/Kafka/Metadata.hs
@@ -45,10 +45,6 @@ import           Kafka.Internal.RdKafka
   , rdKafkaQueryWatermarkOffsets
   , rdKafkaOffsetsForTimes
   , rdKafkaListGroups
---  , groupCnt'RdKafkaGroupListT
---  , groups'RdKafkaGroupListT
---  , brokerCnt'RdKafkaMetadataT
---  , broker
   )
 import           Kafka.Internal.Setup
 import           Kafka.Internal.Shared

--- a/src/Kafka/Metadata.hs
+++ b/src/Kafka/Metadata.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Kafka.Metadata
 ( KafkaMetadata(..), BrokerMetadata(..), TopicMetadata(..), PartitionMetadata(..)
 , WatermarkOffsets(..)
@@ -12,18 +14,42 @@ module Kafka.Metadata
 )
 where
 
+import           Data.Text              (Text)
+import qualified Data.Text              as Text
 import           Control.Arrow          (left)
 import           Control.Exception      (bracket)
-import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Data.Bifunctor
+import           Control.Monad.IO.Class (MonadIO(liftIO))
+import           Data.Bifunctor         (bimap)
 import           Data.ByteString        (ByteString, pack)
 import           Data.Monoid            ((<>))
 import qualified Data.Set               as S
-import           Foreign
-import           Foreign.C.String
-import           Kafka.Consumer.Convert
-import           Kafka.Consumer.Types
+import           Foreign                (withForeignPtr, Storable(peek), peekArray)
+import           Kafka.Consumer.Convert (toNativeTopicPartitionList, fromNativeTopicPartitionList'')
+import           Kafka.Consumer.Types   (Offset(..), ConsumerGroupId(..), TopicPartition(..), PartitionOffset(..))
 import           Kafka.Internal.RdKafka
+  ( RdKafkaGroupListTPtr
+  , RdKafkaMetadataTPtr
+  , RdKafkaMetadataBrokerT(..)
+  , RdKafkaMetadataPartitionT(..)
+  , RdKafkaMetadataTopicT(..)
+  , RdKafkaGroupMemberInfoT(..)
+  , RdKafkaGroupInfoT(..)
+  , RdKafkaGroupListT(..)
+  , RdKafkaTPtr
+  , RdKafkaRespErrT(..)
+  , RdKafkaMetadataT(..)
+  , peekCAText
+  , rdKafkaMetadata
+  , newUnmanagedRdKafkaTopicT
+  , destroyUnmanagedRdKafkaTopic
+  , rdKafkaQueryWatermarkOffsets
+  , rdKafkaOffsetsForTimes
+  , rdKafkaListGroups
+--  , groupCnt'RdKafkaGroupListT
+--  , groups'RdKafkaGroupListT
+--  , brokerCnt'RdKafkaMetadataT
+--  , broker
+  )
 import           Kafka.Internal.Setup
 import           Kafka.Internal.Shared
 import           Kafka.Types
@@ -36,7 +62,7 @@ data KafkaMetadata = KafkaMetadata
 
 data BrokerMetadata = BrokerMetadata
   { bmBrokerId   :: !BrokerId
-  , bmBrokerHost :: !String
+  , bmBrokerHost :: !Text
   , bmBrokerPort :: !Int
   } deriving (Show, Eq)
 
@@ -61,17 +87,17 @@ data WatermarkOffsets = WatermarkOffsets
   , woHighWatermark :: !Offset
   } deriving (Show, Eq)
 
-newtype GroupMemberId = GroupMemberId String deriving (Show, Eq, Read, Ord)
+newtype GroupMemberId = GroupMemberId Text deriving (Show, Eq, Read, Ord)
 data GroupMemberInfo = GroupMemberInfo
   { gmiMemberId   :: !GroupMemberId
   , gmiClientId   :: !ClientId
-  , gmiClientHost :: !String
+  , gmiClientHost :: !Text
   , gmiMetadata   :: !ByteString
   , gmiAssignment :: !ByteString
   } deriving (Show, Eq)
 
-newtype GroupProtocolType = GroupProtocolType String deriving (Show, Eq, Read, Ord)
-newtype GroupProtocol = GroupProtocol String  deriving (Show, Eq, Read, Ord)
+newtype GroupProtocolType = GroupProtocolType Text deriving (Show, Eq, Read, Ord)
+newtype GroupProtocol = GroupProtocol Text  deriving (Show, Eq, Read, Ord)
 data GroupState
   = GroupPreparingRebalance       -- ^ Group is preparing to rebalance
   | GroupEmpty                    -- ^ Group has no more members, but lingers until all offsets have expired
@@ -99,12 +125,12 @@ allTopicsMetadata k (Timeout timeout) = liftIO $ do
 topicMetadata :: (MonadIO m, HasKafka k) => k -> Timeout -> TopicName -> m (Either KafkaError KafkaMetadata)
 topicMetadata k (Timeout timeout) (TopicName tn) = liftIO $
   bracket mkTopic clTopic $ \mbt -> case mbt of
-    Left err -> return (Left $ KafkaError err)
+    Left err -> return (Left $ KafkaError (Text.pack err))
     Right t -> do
       meta <- rdKafkaMetadata (getKafkaPtr k) False (Just t) timeout
       traverse fromKafkaMetadataPtr (left KafkaResponseError meta)
   where
-    mkTopic = newUnmanagedRdKafkaTopicT (getKafkaPtr k) tn Nothing
+    mkTopic = newUnmanagedRdKafkaTopicT (getKafkaPtr k) (Text.unpack tn) Nothing
     clTopic = either (return . const ()) destroyUnmanagedRdKafkaTopic
 
 -- | Query broker for low (oldest/beginning) and high (newest/end) offsets for a given topic.
@@ -126,7 +152,7 @@ watermarkOffsets' k timeout tm =
 -- | Query broker for low (oldest/beginning) and high (newest/end) offsets for a specific partition
 partitionWatermarkOffsets :: (MonadIO m, HasKafka k) => k -> Timeout -> TopicName -> PartitionId -> m (Either KafkaError WatermarkOffsets)
 partitionWatermarkOffsets k (Timeout timeout) (TopicName t) (PartitionId p) = liftIO $ do
-  offs <- rdKafkaQueryWatermarkOffsets (getKafkaPtr k) t p timeout
+  offs <- rdKafkaQueryWatermarkOffsets (getKafkaPtr k) (Text.unpack t) p timeout
   return $ bimap KafkaResponseError toWatermark offs
   where
     toWatermark (l, h) = WatermarkOffsets (TopicName t) (PartitionId p) (Offset l) (Offset h)
@@ -181,7 +207,7 @@ allConsumerGroupsInfo k (Timeout t) = liftIO $ do
 -- | Describe a given consumer group.
 consumerGroupInfo :: (MonadIO m, HasKafka k) => k -> Timeout -> ConsumerGroupId -> m (Either KafkaError [GroupInfo])
 consumerGroupInfo k (Timeout timeout) (ConsumerGroupId gn) = liftIO $ do
-  res <- rdKafkaListGroups (getKafkaPtr k) (Just gn) timeout
+  res <- rdKafkaListGroups (getKafkaPtr k) (Just (Text.unpack gn)) timeout
   traverse fromGroupInfoListPtr (left KafkaResponseError res)
 
 -------------------------------------------------------------------------------
@@ -201,10 +227,10 @@ fromGroupInfoPtr :: RdKafkaGroupInfoT -> IO GroupInfo
 fromGroupInfoPtr gi = do
   --bmd <- peek (broker'RdKafkaGroupInfoT gi) -- >>= fromBrokerMetadataPtr
   --xxx <- fromBrokerMetadataPtr bmd
-  cid <- peekCAString $ group'RdKafkaGroupInfoT gi
-  stt <- peekCAString $ state'RdKafkaGroupInfoT gi
-  prt <- peekCAString $ protocolType'RdKafkaGroupInfoT gi
-  pr  <- peekCAString $ protocol'RdKafkaGroupInfoT gi
+  cid <- peekCAText $ group'RdKafkaGroupInfoT gi
+  stt <- peekCAText $ state'RdKafkaGroupInfoT gi
+  prt <- peekCAText $ protocolType'RdKafkaGroupInfoT gi
+  pr  <- peekCAText $ protocol'RdKafkaGroupInfoT gi
   mbs <- peekArray (memberCnt'RdKafkaGroupInfoT gi) (members'RdKafkaGroupInfoT gi)
   mbl <- mapM fromGroupMemberInfoPtr mbs
   return GroupInfo
@@ -219,9 +245,9 @@ fromGroupInfoPtr gi = do
 
 fromGroupMemberInfoPtr :: RdKafkaGroupMemberInfoT -> IO GroupMemberInfo
 fromGroupMemberInfoPtr mi = do
-  mid <- peekCAString $ memberId'RdKafkaGroupMemberInfoT mi
-  cid <- peekCAString $ clientId'RdKafkaGroupMemberInfoT mi
-  hst <- peekCAString $ clientHost'RdKafkaGroupMemberInfoT mi
+  mid <- peekCAText $ memberId'RdKafkaGroupMemberInfoT mi
+  cid <- peekCAText $ clientId'RdKafkaGroupMemberInfoT mi
+  hst <- peekCAText $ clientHost'RdKafkaGroupMemberInfoT mi
   mtd <- peekArray (memberMetadataSize'RdKafkaGroupMemberInfoT mi) (memberMetadata'RdKafkaGroupMemberInfoT mi)
   ass <- peekArray (memberAssignmentSize'RdKafkaGroupMemberInfoT mi) (memberAssignment'RdKafkaGroupMemberInfoT mi)
   return GroupMemberInfo
@@ -234,7 +260,7 @@ fromGroupMemberInfoPtr mi = do
 
 fromTopicMetadataPtr :: RdKafkaMetadataTopicT -> IO TopicMetadata
 fromTopicMetadataPtr tm = do
-  tnm <- peekCAString (topic'RdKafkaMetadataTopicT tm)
+  tnm <- peekCAText (topic'RdKafkaMetadataTopicT tm)
   pts <- peekArray (partitionCnt'RdKafkaMetadataTopicT tm) (partitions'RdKafkaMetadataTopicT tm)
   pms <- mapM fromPartitionMetadataPtr pts
   return TopicMetadata
@@ -258,7 +284,7 @@ fromPartitionMetadataPtr pm = do
 
 fromBrokerMetadataPtr :: RdKafkaMetadataBrokerT -> IO BrokerMetadata
 fromBrokerMetadataPtr bm = do
-    host <- peekCAString (host'RdKafkaMetadataBrokerT bm)
+    host <- peekCAText (host'RdKafkaMetadataBrokerT bm)
     return BrokerMetadata
       { bmBrokerId   = BrokerId (id'RdKafkaMetadataBrokerT bm)
       , bmBrokerHost = host
@@ -280,11 +306,11 @@ fromKafkaMetadataPtr ptr =
       , kmOrigBroker = BrokerId $ fromIntegral (origBrokerId'RdKafkaMetadataT km)
       }
 
-groupStateFromKafkaString :: String -> GroupState
+groupStateFromKafkaString :: Text -> GroupState
 groupStateFromKafkaString s = case s of
   "PreparingRebalance" -> GroupPreparingRebalance
   "AwaitingSync"       -> GroupAwaitingSync
   "Stable"             -> GroupStable
   "Dead"               -> GroupDead
   "Empty"              -> GroupEmpty
-  _                    -> error $ "Unknown group state: " <> s
+  _                    -> error $ "Unknown group state: " <> (Text.unpack s)

--- a/src/Kafka/Metadata.hs
+++ b/src/Kafka/Metadata.hs
@@ -46,9 +46,17 @@ import           Kafka.Internal.RdKafka
   , rdKafkaOffsetsForTimes
   , rdKafkaListGroups
   )
-import           Kafka.Internal.Setup
-import           Kafka.Internal.Shared
+import           Kafka.Internal.Setup   (Kafka(..), HasKafka(..))
+import           Kafka.Internal.Shared  (kafkaErrorToMaybe)
 import           Kafka.Types
+  ( BrokerId(..)
+  , ClientId(..)
+  , KafkaError(..)
+  , Millis(..)
+  , PartitionId(..)
+  , Timeout(..)
+  , TopicName(..)
+  )
 
 data KafkaMetadata = KafkaMetadata
   { kmBrokers    :: [BrokerMetadata]

--- a/src/Kafka/Producer/Callbacks.hs
+++ b/src/Kafka/Producer/Callbacks.hs
@@ -4,15 +4,16 @@ module Kafka.Producer.Callbacks
 )
 where
 
-import           Foreign
-import           Foreign.C.Error
+import           Foreign.C.Error        (getErrno)
+import           Foreign.Ptr            (Ptr, nullPtr)
+import           Foreign.Storable       (Storable(peek))
 import           Kafka.Callbacks        as X
-import           Kafka.Consumer.Types
-import           Kafka.Internal.RdKafka
-import           Kafka.Internal.Setup
-import           Kafka.Internal.Shared
-import           Kafka.Producer.Types
-import           Kafka.Types
+import           Kafka.Consumer.Types   (Offset(..))
+import           Kafka.Internal.RdKafka (RdKafkaMessageT(..), RdKafkaRespErrT(..), rdKafkaConfSetDrMsgCb)
+import           Kafka.Internal.Setup   (KafkaConf(..), getRdKafkaConf)
+import           Kafka.Internal.Shared  (kafkaRespErr, readTopic, readKey, readPayload)
+import           Kafka.Producer.Types   (ProducerRecord(..), DeliveryReport(..), ProducePartition(..))
+import           Kafka.Types            (KafkaError(..), TopicName(..))
 
 -- | Sets the callback for delivery reports.
 deliveryCallback :: (DeliveryReport -> IO ()) -> KafkaConf -> IO ()

--- a/src/Kafka/Producer/Convert.hs
+++ b/src/Kafka/Producer/Convert.hs
@@ -6,12 +6,12 @@ module Kafka.Producer.Convert
 )
 where
 
-import           Foreign.C.Error
-import           Foreign.C.Types
-import           Kafka.Internal.RdKafka
-import           Kafka.Internal.Shared
-import           Kafka.Types
-import           Kafka.Producer.Types
+import           Foreign.C.Error        (getErrno)
+import           Foreign.C.Types        (CInt)
+import           Kafka.Internal.RdKafka (rdKafkaMsgFlagCopy)
+import           Kafka.Internal.Shared  (kafkaRespErr)
+import           Kafka.Types            (KafkaError(..))
+import           Kafka.Producer.Types   (ProducePartition(..))
 
 copyMsgFlags :: Int
 copyMsgFlags = rdKafkaMsgFlagCopy

--- a/src/Kafka/Producer/Convert.hs
+++ b/src/Kafka/Producer/Convert.hs
@@ -1,4 +1,9 @@
 module Kafka.Producer.Convert
+( copyMsgFlags
+, producePartitionInt
+, producePartitionCInt
+, handleProduceErr
+)
 where
 
 import           Foreign.C.Error

--- a/src/Kafka/Producer/ProducerProperties.hs
+++ b/src/Kafka/Producer/ProducerProperties.hs
@@ -1,13 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Kafka.Producer.ProducerProperties
-( module Kafka.Producer.ProducerProperties
+( ProducerProperties(..)
+, brokersList
+, setCallback
+, logLevel
+, compression
+, topicCompression
+, sendTimeout
+, extraProps
+, suppressDisconnectLogs
+, extraTopicProps
+, debugOptions
 , module Kafka.Producer.Callbacks
 )
 where
 
-import           Data.Text (Text)
-import qualified Data.Text as Text
+import           Data.Text                (Text)
+import qualified Data.Text                as Text
 import           Control.Monad
 import           Data.Map                 (Map)
 import qualified Data.Map                 as M

--- a/src/Kafka/Producer/ProducerProperties.hs
+++ b/src/Kafka/Producer/ProducerProperties.hs
@@ -18,13 +18,14 @@ where
 
 import           Data.Text                (Text)
 import qualified Data.Text                as Text
-import           Control.Monad
+import           Control.Monad            (MonadPlus(mplus))
 import           Data.Map                 (Map)
 import qualified Data.Map                 as M
 import           Data.Semigroup           as Sem
-import           Kafka.Internal.Setup
+import           Kafka.Internal.Setup     (KafkaConf(..))
+import           Kafka.Types              (KafkaDebug(..), Timeout(..), KafkaCompressionCodec(..), KafkaLogLevel(..), BrokerAddress(..), kafkaDebugToText, kafkaCompressionCodecToText)  
+
 import           Kafka.Producer.Callbacks
-import           Kafka.Types
 
 -- | Properties to create 'KafkaProducer'.
 data ProducerProperties = ProducerProperties

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Kafka.Producer.Types
-
+( KafkaProducer(..)
+, ProducerRecord(..)
+, ProducePartition(..)
+, DeliveryReport(..)
+)
 where
 
 import qualified Data.ByteString      as BS

--- a/src/Kafka/Producer/Types.hs
+++ b/src/Kafka/Producer/Types.hs
@@ -8,10 +8,10 @@ module Kafka.Producer.Types
 where
 
 import qualified Data.ByteString      as BS
-import           Data.Typeable
-import           Kafka.Internal.Setup
-import           Kafka.Types
-import Kafka.Consumer.Types
+import           Data.Typeable        (Typeable)
+import           Kafka.Internal.Setup (HasKafka(..), HasKafkaConf(..), HasTopicConf(..), Kafka(..), KafkaConf(..), TopicConf(..))
+import           Kafka.Types          (TopicName(..), KafkaError(..))
+import           Kafka.Consumer.Types (Offset(..))
 
 -- | Main pointer to Kafka object, which contains our brokers
 data KafkaProducer = KafkaProducer

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
 module Kafka.Types
 where
 
-import Control.Exception
-import Data.Int
-import Data.Typeable
-import Kafka.Internal.RdKafka
+import Control.Exception (Exception(..))
+import Data.Int (Int64)
+import Data.Typeable (Typeable)
+import Kafka.Internal.RdKafka (RdKafkaRespErrT, rdKafkaErr2name, rdKafkaErr2str)
+import Data.Text (Text)
 
-newtype BrokerId = BrokerId { unBrokerId :: Int} deriving (Show, Eq, Ord, Read)
+newtype BrokerId = BrokerId { unBrokerId :: Int } deriving (Show, Eq, Ord, Read)
 
-newtype PartitionId = PartitionId { unPartitionId :: Int} deriving (Show, Eq, Read, Ord, Enum)
+newtype PartitionId = PartitionId { unPartitionId :: Int } deriving (Show, Eq, Read, Ord, Enum)
 newtype Millis      = Millis { unMillis :: Int64 } deriving (Show, Read, Eq, Ord, Num)
-newtype ClientId    = ClientId { unClientId :: String} deriving (Show, Eq, Ord)
+newtype ClientId    = ClientId { unClientId :: Text } deriving (Show, Eq, Ord)
 newtype BatchSize   = BatchSize { unBatchSize :: Int } deriving (Show, Read, Eq, Ord, Num)
 
 -- | Topic name to be consumed
@@ -22,11 +25,11 @@ newtype BatchSize   = BatchSize { unBatchSize :: Int } deriving (Show, Read, Eq,
 -- be regex-matched to the full list of topics in the cluster and matching
 -- topics will be added to the subscription list.
 newtype TopicName =
-    TopicName { unTopicName :: String } -- ^ a simple topic name or a regex if started with @^@
+    TopicName { unTopicName :: Text } -- ^ a simple topic name or a regex if started with @^@
     deriving (Show, Eq, Ord, Read)
 
 -- | Kafka broker address string (e.g. @broker1:9092@)
-newtype BrokerAddress = BrokerAddress { unBrokerAddress :: String } deriving (Show, Eq)
+newtype BrokerAddress = BrokerAddress { unBrokerAddress :: Text } deriving (Show, Eq)
 
 -- | Timeout in milliseconds
 newtype Timeout = Timeout { unTimeout :: Int } deriving (Show, Eq, Read)
@@ -60,12 +63,12 @@ instance Enum KafkaLogLevel where
 --
 -- | Any Kafka errors
 data KafkaError =
-    KafkaError String
+    KafkaError Text
   | KafkaInvalidReturnValue
-  | KafkaBadSpecification String
+  | KafkaBadSpecification Text
   | KafkaResponseError RdKafkaRespErrT
-  | KafkaInvalidConfigurationValue String
-  | KafkaUnknownConfigurationKey String
+  | KafkaInvalidConfigurationValue Text
+  | KafkaUnknownConfigurationKey Text
   | KafkaBadConfiguration
     deriving (Eq, Show, Typeable)
 
@@ -89,8 +92,8 @@ data KafkaDebug =
   | DebugAll
   deriving (Eq, Show, Typeable)
 
-kafkaDebugToString :: KafkaDebug -> String
-kafkaDebugToString d =case d of
+kafkaDebugToText :: KafkaDebug -> Text
+kafkaDebugToText d = case d of
   DebugGeneric  -> "generic"
   DebugBroker   -> "broker"
   DebugTopic    -> "topic"
@@ -111,8 +114,8 @@ data KafkaCompressionCodec =
   | Lz4
   deriving (Eq, Show, Typeable)
 
-kafkaCompressionCodecToString :: KafkaCompressionCodec -> String
-kafkaCompressionCodecToString c = case c of
+kafkaCompressionCodecToText :: KafkaCompressionCodec -> Text
+kafkaCompressionCodecToText c = case c of
   NoCompression -> "none"
   Gzip          -> "gzip"
   Snappy        -> "snappy"

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -38,27 +38,7 @@ newtype Timeout = Timeout { unTimeout :: Int } deriving (Show, Eq, Read)
 data KafkaLogLevel =
   KafkaLogEmerg | KafkaLogAlert | KafkaLogCrit | KafkaLogErr | KafkaLogWarning |
   KafkaLogNotice | KafkaLogInfo | KafkaLogDebug
-  deriving (Show, Eq)
-
-instance Enum KafkaLogLevel where
-   toEnum 0 = KafkaLogEmerg
-   toEnum 1 = KafkaLogAlert
-   toEnum 2 = KafkaLogCrit
-   toEnum 3 = KafkaLogErr
-   toEnum 4 = KafkaLogWarning
-   toEnum 5 = KafkaLogNotice
-   toEnum 6 = KafkaLogInfo
-   toEnum 7 = KafkaLogDebug
-   toEnum _ = undefined
-
-   fromEnum KafkaLogEmerg   = 0
-   fromEnum KafkaLogAlert   = 1
-   fromEnum KafkaLogCrit    = 2
-   fromEnum KafkaLogErr     = 3
-   fromEnum KafkaLogWarning = 4
-   fromEnum KafkaLogNotice  = 5
-   fromEnum KafkaLogInfo    = 6
-   fromEnum KafkaLogDebug   = 7
+  deriving (Show, Enum, Eq)
 
 --
 -- | Any Kafka errors

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -3,6 +3,21 @@
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Kafka.Types
+( BrokerId(..)
+, PartitionId(..)
+, Millis(..)
+, ClientId(..)
+, BatchSize(..)
+, TopicName(..)
+, BrokerAddress(..)
+, Timeout(..)
+, KafkaLogLevel(..)
+, KafkaError(..)
+, KafkaDebug(..)
+, KafkaCompressionCodec(..)
+, kafkaDebugToText
+, kafkaCompressionCodecToText
+)
 where
 
 import Control.Exception (Exception(..))

--- a/tests-it/Kafka/IntegrationSpec.hs
+++ b/tests-it/Kafka/IntegrationSpec.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString     as BS
 import           Data.Either
 import           Data.Map
 import           Data.Monoid         ((<>))
-import           Data.Text           (Text)
 
 import Kafka.Consumer as C
 import Kafka.Metadata as M

--- a/tests-it/Kafka/IntegrationSpec.hs
+++ b/tests-it/Kafka/IntegrationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/tests-it/Kafka/IntegrationSpec.hs
+++ b/tests-it/Kafka/IntegrationSpec.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString     as BS
 import           Data.Either
 import           Data.Map
 import           Data.Monoid         ((<>))
+import           Data.Text           (Text)
 
 import Kafka.Consumer as C
 import Kafka.Metadata as M

--- a/tests-it/Kafka/TestEnv.hs
+++ b/tests-it/Kafka/TestEnv.hs
@@ -8,6 +8,8 @@ import Control.Monad      (void)
 import Data.Monoid        ((<>))
 import System.Environment
 import System.IO.Unsafe
+import Data.Text          (Text)
+import qualified Data.Text as Text
 
 import Control.Concurrent
 import Kafka.Consumer     as C
@@ -17,12 +19,12 @@ import Test.Hspec
 
 brokerAddress :: BrokerAddress
 brokerAddress = unsafePerformIO $
-  BrokerAddress <$> getEnv "KAFKA_TEST_BROKER" `catch` \(_ :: SomeException) -> (return "localhost:9092")
+  (BrokerAddress . Text.pack) <$> getEnv "KAFKA_TEST_BROKER" `catch` \(_ :: SomeException) -> (return "localhost:9092")
 {-# NOINLINE brokerAddress #-}
 
 testTopic :: TopicName
 testTopic = unsafePerformIO $
-  TopicName <$> getEnv "KAFKA_TEST_TOPIC" `catch` \(_ :: SomeException) -> (return "kafka-client_tests")
+  (TopicName . Text.pack) <$> getEnv "KAFKA_TEST_TOPIC" `catch` \(_ :: SomeException) -> (return "kafka-client_tests")
 {-# NOINLINE testTopic #-}
 
 testGroupId :: ConsumerGroupId

--- a/tests-it/Kafka/TestEnv.hs
+++ b/tests-it/Kafka/TestEnv.hs
@@ -8,7 +8,6 @@ import Control.Monad      (void)
 import Data.Monoid        ((<>))
 import System.Environment
 import System.IO.Unsafe
-import Data.Text          (Text)
 import qualified Data.Text as Text
 
 import Control.Concurrent

--- a/tests-it/Kafka/TestEnv.hs
+++ b/tests-it/Kafka/TestEnv.hs
@@ -18,12 +18,12 @@ import Kafka.Producer     as P
 import Test.Hspec
 
 brokerAddress :: BrokerAddress
-brokerAddress = unsafePerformIO $
+brokerAddress = unsafePerformIO $ do
   (BrokerAddress . Text.pack) <$> getEnv "KAFKA_TEST_BROKER" `catch` \(_ :: SomeException) -> (return "localhost:9092")
 {-# NOINLINE brokerAddress #-}
 
 testTopic :: TopicName
-testTopic = unsafePerformIO $
+testTopic = unsafePerformIO $ do
   (TopicName . Text.pack) <$> getEnv "KAFKA_TEST_TOPIC" `catch` \(_ :: SomeException) -> (return "kafka-client_tests")
 {-# NOINLINE testTopic #-}
 
@@ -50,9 +50,7 @@ testSubscription t = topics [t]
               <> offsetReset Earliest
 
 mkProducer :: IO KafkaProducer
-mkProducer = do
-    (Right p) <- newProducer producerProps
-    return p
+mkProducer = newProducer producerProps >>= \(Right p) -> pure p
 
 mkConsumerWith :: ConsumerProperties -> IO KafkaConsumer
 mkConsumerWith props = do

--- a/tests/Kafka/Consumer/ConsumerRecordMapSpec.hs
+++ b/tests/Kafka/Consumer/ConsumerRecordMapSpec.hs
@@ -7,12 +7,13 @@ import Data.Bitraversable
 import Kafka.Consumer.Types
 import Kafka.Types
 import Test.Hspec
+import Data.Text
 
-testKey, testValue :: String
+testKey, testValue :: Text
 testKey   = "some-key"
 testValue = "some-value"
 
-testRecord :: ConsumerRecord (Maybe String) (Maybe String)
+testRecord :: ConsumerRecord (Maybe Text) (Maybe Text)
 testRecord = ConsumerRecord
   { crTopic     = TopicName "some-topic"
   , crPartition = PartitionId 0

--- a/tests/Kafka/Consumer/ConsumerRecordTraverseSpec.hs
+++ b/tests/Kafka/Consumer/ConsumerRecordTraverseSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Kafka.Consumer.ConsumerRecordTraverseSpec
 ( spec
 ) where
@@ -8,12 +9,13 @@ import Data.Bitraversable
 import Kafka.Consumer.Types
 import Kafka.Types
 import Test.Hspec
+import Data.Text
 
-testKey, testValue :: String
+testKey, testValue :: Text
 testKey   = "some-key"
 testValue = "some-value"
 
-testRecord :: ConsumerRecord String String
+testRecord :: ConsumerRecord Text Text
 testRecord = ConsumerRecord
   { crTopic     = TopicName "some-topic"
   , crPartition = PartitionId 0


### PR DESCRIPTION
This PR attempts to do the following:

1. use `Text` instead of `String`
2. use `Map Text Text` instead of `[(String, String)]`
3. get rid of hand-written instance for KafkaLogLevel, whose derived instance is strictly better
4. add explicit import/export lists (good for haddock and developing!)
5. Subscription constructor now takes `Set TopicName`, instead of `[TopicName]`, since they're a unique, ordered set of `TopicName`s. This is not only more efficient as a structure, but also avoids the /O(n^2)/ calls to `Data.List.nub`.
6. add nix expression that lets you drop into an environment with a sufficiently new librdkafka

All tests pass on this branch.