### PR TITLE
Admin client: Migrate to Text

### DIFF
--- a/src/Kafka/Admin/AdminProperties.hs
+++ b/src/Kafka/Admin/AdminProperties.hs
@@ -1,17 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Kafka.Admin.AdminProperties
 where
 
 import           Control.Monad  (mplus)
-import qualified Data.List      as L
 import           Data.Map       (Map)
 import qualified Data.Map       as M
 import           Data.Monoid    (Monoid, mempty)
 import           Data.Semigroup (Semigroup, (<>))
+import           Data.Text      (Text)
+import qualified Data.Text      as Text
 import           Kafka.Types
 
 -- | Properties to create 'KafkaProducer'.
 data AdminProperties = AdminProperties
-  { apKafkaProps :: Map String String
+  { apKafkaProps :: Map Text Text
   , apLogLevel   :: Maybe KafkaLogLevel
   }
 
@@ -32,12 +35,12 @@ instance Monoid AdminProperties where
 
 brokersList :: [BrokerAddress] -> AdminProperties
 brokersList bs =
-  let bs' = L.intercalate "," ((\(BrokerAddress x) -> x) <$> bs)
+  let bs' = Text.intercalate "," ((\(BrokerAddress x) -> x) <$> bs)
    in extraProps $ M.fromList [("bootstrap.servers", bs')]
 
 -- | Any configuration options that are supported by /librdkafka/.
 -- The full list can be found <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md here>
-extraProps :: Map String String -> AdminProperties
+extraProps :: Map Text Text -> AdminProperties
 extraProps m = mempty { apKafkaProps = m }
 
 -- | Suppresses producer disconnects logs.

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -1059,7 +1059,7 @@ rdKafkaEventCreateTopicsResult evtPtr =
       else Just <$> newForeignPtr_ (castPtr res)
 
 rdKafkaCreateTopicsResultTopics :: RdKafkaCreateTopicsResultTPtr
-                                -> IO [Either (String, RdKafkaRespErrT, String) String]
+                                -> IO [Either (Text, RdKafkaRespErrT, Text) Text]
 rdKafkaCreateTopicsResultTopics tRes =
   withForeignPtr tRes $ \tRes' ->
     alloca $ \sPtr -> do
@@ -1103,8 +1103,7 @@ rdKafkaEventDeleteTopicsResult evtPtr =
       then pure Nothing
       else Just <$> newForeignPtr_ (castPtr res)
 
-rdKafkaDeleteTopicsResultTopics :: RdKafkaDeleteTopicsResultTPtr
-                                -> IO [Either (String, RdKafkaRespErrT, String) String]
+rdKafkaDeleteTopicsResultTopics :: RdKafkaDeleteTopicsResultTPtr -> IO [Either (Text, RdKafkaRespErrT, Text) Text]
 rdKafkaDeleteTopicsResultTopics tRes =
   withForeignPtr tRes $ \tRes' ->
     alloca $ \sPtr -> do
@@ -1117,15 +1116,15 @@ rdKafkaDeleteTopicsResultTopics tRes =
 -- | Unpacks raw result into
 -- 'Either (topicName, errorType, errorMsg) topicName'
 unpackRdKafkaTopicResult :: Ptr RdKafkaTopicResultT
-                         -> IO (Either (String, RdKafkaRespErrT, String) String)
+                         -> IO (Either (Text, RdKafkaRespErrT, Text) Text)
 unpackRdKafkaTopicResult resPtr = do
   name <- {#call rd_kafka_topic_result_name#} resPtr >>= peekCString
   err <- {#call rd_kafka_topic_result_error#} resPtr
   case cIntToEnum err of
-    RdKafkaRespErrNoError -> pure $ Right name
+    RdKafkaRespErrNoError -> pure . Right $ Text.pack name
     respErr -> do
       errMsg <- {#call rd_kafka_topic_result_error_string#} resPtr >>= peekCString
-      pure $ Left (name, respErr, errMsg)
+      pure $ Left (Text.pack name, respErr, Text.pack errMsg)
 
 
 ---------------------------------------------------------------------------------------------------

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -1019,22 +1019,22 @@ rdKafkaNewTopicDestroyArray ts = do
   withForeignPtrsArrayLen ts $ \llen ptrs ->
     {#call rd_kafka_NewTopic_destroy_array#} ptrs (fromIntegral llen)
 
-newRdKafkaNewTopic :: String -> Int -> Int -> IO (Either String RdKafkaNewTopicTPtr)
+newRdKafkaNewTopic :: Text -> Int -> Int -> IO (Either Text RdKafkaNewTopicTPtr)
 newRdKafkaNewTopic name partitions repFactor = do
     allocaBytes nErrorBytes $ \strPtr -> do
-        ret <- rdKafkaNewTopicNew name partitions repFactor strPtr (fromIntegral nErrorBytes)
+        ret <- rdKafkaNewTopicNew (Text.unpack name) partitions repFactor strPtr (fromIntegral nErrorBytes)
         withForeignPtr ret $ \realPtr -> do
             if realPtr == nullPtr
-                then peekCString strPtr >>= pure . Left
+                then peekCText strPtr >>= pure . Left
                 else addForeignPtrFinalizer rdKafkaNewTopicDestroy ret >> pure (Right ret)
 
-newRdKafkaNewTopicUnsafe :: String -> Int -> Int -> IO (Either String RdKafkaNewTopicTPtr)
+newRdKafkaNewTopicUnsafe :: Text -> Int -> Int -> IO (Either Text RdKafkaNewTopicTPtr)
 newRdKafkaNewTopicUnsafe name partitions repFactor = do
     allocaBytes nErrorBytes $ \strPtr -> do
-        ret <- rdKafkaNewTopicNew name partitions repFactor strPtr (fromIntegral nErrorBytes)
+        ret <- rdKafkaNewTopicNew (Text.unpack name) partitions repFactor strPtr (fromIntegral nErrorBytes)
         withForeignPtr ret $ \realPtr -> do
             if realPtr == nullPtr
-                then peekCString strPtr >>= pure . Left
+                then peekCText strPtr >>= pure . Left
                 else pure (Right ret)
 
 {#fun rd_kafka_NewTopic_set_config as ^


### PR DESCRIPTION
Hey @AlexeyRaga 

I have never used FFI/C bindings in Haskell yet so I definitely don't feel confident toying around with those additional admin bindings yet.
However I am more comfortable on "good ol' Haskell" so I did migrate all `String`s to `Text` as you mentioned the need in #118 (and I get this is tedious, you'd rather focus on the Admin API per se).

All tests pass (`stack init && stack test`) but I am far from being confident I did not break something along the way :smile: 

I (and my team) could most likely help for the "good ol' Haskell" part, but I don't think we have the level for the C bindings part (`*.chs`). Feel free to ping me if we can help!

Please note, there are some remaining warnings (unused fields, etc.) which were already there so I'm not touching those in this PR.

Cheers