### PR TITLE
doc(kafka): Add documentation

### DIFF
--- a/src/Kafka/Consumer/Subscription.hs
+++ b/src/Kafka/Consumer/Subscription.hs
@@ -17,6 +17,18 @@ import           Data.Text            (Text)
 import           Kafka.Consumer.Types (OffsetReset (..))
 import           Kafka.Types          (TopicName (..))
 
+-- | A consumer subscription to a topic.
+--
+-- ==== __Examples__
+--
+-- Typically you don't call the constructor directly, but combine settings:
+--
+-- @
+-- consumerSub :: 'Subscription'
+-- consumerSub = 'topics' ['TopicName' "kafka-client-example-topic"]
+--         <> 'offsetReset' 'Earliest'
+--         <> 'extraSubscriptionProps' (fromList [("prop1", "value 1"), ("prop2", "value 2")])
+-- @
 data Subscription = Subscription (Set TopicName) (Map Text Text)
 
 instance Sem.Semigroup Subscription where
@@ -32,9 +44,11 @@ instance Monoid Subscription where
   mappend = (Sem.<>)
   {-# INLINE mappend #-}
 
+-- | Build a subscription by giving the list of topic names only
 topics :: [TopicName] -> Subscription
 topics ts = Subscription (Set.fromList ts) M.empty
 
+-- | Build a subscription by giving the offset reset parameter only
 offsetReset :: OffsetReset -> Subscription
 offsetReset o =
   let o' = case o of
@@ -42,5 +56,6 @@ offsetReset o =
              Latest   -> "latest"
    in Subscription Set.empty (M.fromList [("auto.offset.reset", o')])
 
+-- | Build a subscription by giving extra properties only
 extraSubscriptionProps :: Map Text Text -> Subscription
 extraSubscriptionProps = Subscription Set.empty

--- a/src/Kafka/Producer.hs
+++ b/src/Kafka/Producer.hs
@@ -41,7 +41,7 @@ import Kafka.Types                       as X
 -- | Runs Kafka Producer.
 -- The callback provided is expected to call 'produceMessage'
 -- or/and 'produceMessageBatch' to send messages to Kafka.
-{-# DEPRECATED runProducer "Use newProducer/closeProducer instead" #-}
+{-# DEPRECATED runProducer "Use 'newProducer'/'closeProducer' instead" #-}
 runProducer :: ProducerProperties
             -> (KafkaProducer -> IO (Either KafkaError a))
             -> IO (Either KafkaError a)

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -29,16 +29,27 @@ import Data.Typeable          (Typeable)
 import GHC.Generics           (Generic)
 import Kafka.Internal.RdKafka (RdKafkaRespErrT, rdKafkaErr2name, rdKafkaErr2str)
 
+-- | Kafka broker ID
 newtype BrokerId = BrokerId { unBrokerId :: Int } deriving (Show, Eq, Ord, Read, Generic)
 
+-- | Topic partition ID
 newtype PartitionId = PartitionId { unPartitionId :: Int } deriving (Show, Eq, Read, Ord, Enum, Generic)
+
+-- | A number of milliseconds, used to represent durations and timestamps
 newtype Millis      = Millis { unMillis :: Int64 } deriving (Show, Read, Eq, Ord, Num, Generic)
+
+-- | Client ID used by Kafka to better track requests
+-- 
+-- See <https://kafka.apache.org/documentation/#client.id Kafka documentation on client ID>
 newtype ClientId    = ClientId { unClientId :: Text } deriving (Show, Eq, Ord, Generic)
+
+-- | Batch size used for polling
 newtype BatchSize   = BatchSize { unBatchSize :: Int } deriving (Show, Read, Eq, Ord, Num, Generic)
 
+-- | Whether the topic is created by a user or by the system
 data TopicType =
     User    -- ^ Normal topics that are created by user.
-  | System  -- ^ Topics starting with "__" (__consumer_offsets, __confluent.support.metrics) are considered "system" topics
+  | System  -- ^ Topics starting with a double underscore "\__" (@__consumer_offsets@, @__confluent.support.metrics@, etc.) are considered "system" topics
   deriving (Show, Read, Eq, Ord, Generic)
 
 -- | Topic name to be consumed
@@ -51,6 +62,7 @@ newtype TopicName =
     TopicName { unTopicName :: Text } -- ^ a simple topic name or a regex if started with @^@
     deriving (Show, Eq, Ord, Read, Generic)
 
+-- | Deduce the type of a topic from its name, by checking if it starts with a double underscore "\__"
 topicType :: TopicName -> TopicType
 topicType (TopicName tn) =
   if "__" `isPrefixOf` tn then System else User
@@ -68,8 +80,7 @@ data KafkaLogLevel =
   KafkaLogNotice | KafkaLogInfo | KafkaLogDebug
   deriving (Show, Enum, Eq)
 
---
--- | Any Kafka errors
+-- | All possible Kafka errors
 data KafkaError =
     KafkaError Text
   | KafkaInvalidReturnValue
@@ -85,6 +96,7 @@ instance Exception KafkaError where
     "[" ++ rdKafkaErr2name err ++ "] " ++ rdKafkaErr2str err
   displayException err = show err
 
+-- | Available /librdkafka/ debug contexts
 data KafkaDebug =
     DebugGeneric
   | DebugBroker
@@ -100,6 +112,9 @@ data KafkaDebug =
   | DebugAll
   deriving (Eq, Show, Typeable, Generic)
 
+-- | Convert a 'KafkaDebug' into its /librdkafka/ string equivalent.
+--
+-- This is used internally by the library but may be useful to some developers. 
 kafkaDebugToText :: KafkaDebug -> Text
 kafkaDebugToText d = case d of
   DebugGeneric  -> "generic"
@@ -115,6 +130,9 @@ kafkaDebugToText d = case d of
   DebugFeature  -> "feature"
   DebugAll      -> "all"
 
+-- | Compression codec used by a topic
+--
+-- See <https://kafka.apache.org/documentation/#compression.type Kafka documentation on compression codecs>
 data KafkaCompressionCodec =
     NoCompression
   | Gzip
@@ -122,6 +140,9 @@ data KafkaCompressionCodec =
   | Lz4
   deriving (Eq, Show, Typeable, Generic)
 
+-- | Convert a 'KafkaCompressionCodec' into its /librdkafka/ string equivalent.
+--
+-- This is used internally by the library but may be useful to some developers.
 kafkaCompressionCodecToText :: KafkaCompressionCodec -> Text
 kafkaCompressionCodecToText c = case c of
   NoCompression -> "none"


### PR DESCRIPTION
Hi @AlexeyRaga 

Having used this library for a while (and it works pretty much flawlessly), I think it's time I contribute back to it!
What better way to contribute to a Haskell library than to (try to) improve documentation for future users :smile:

Here's a first PR where I added various documentation, mainly for Consumer module (and common types which appear in Consumer).

Note that I wasn't always sure what was from Kafka, what was from `librdkafka` and what was specific to this library, I did my best but please check and let me know if I made mistakes.

When pure Kafka stuff, I tried to add links to Kafka documentation to help users know how to configure (e.g. the `ResetOffset`)

When `librdkafka` stuff, I did my best to understand what's going on (I've improved on reading the C-Haskell binding file but I can't claim I'm fluent yet :smile: ) and explain accordingly. I would be surprised if I didn't do any mistake, or misexplained (is that even a word?) some things.

* Document common types/functions
* Document Consumer types and functions
* Add module documentation (full example from readme)
* Fix links to replacements for deprecated functions

If you're ok with this PR, I will find some time to add documentation for Producer and other modules in another PR.

Again, thank you for this library, it's awesome and It Just Works™, we've been using it for 1 year in production. I hope this PR serves this library well!