### PR TITLE
tech(nix): Add nettools to shell.nix for ifconfig

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     zlib
     rdkafka
+    nettools
   ];
 
   shellHook = ''


### PR DESCRIPTION
I **finally** got the Windows 2004 upgrade, meaning I can finally work back on libraries like hw-kafka-client 😄 

While building, I noticed `ifconfig` is needed for integration tests, however the `shell.nix` doesn't provide it.

1 (tiny) step further in the autonomous Nix environment