### PR TITLE
Wrap callbacks in newtype to make wrong usage harder

### DIFF
--- a/src/Kafka/Consumer.hs
+++ b/src/Kafka/Consumer.hs
@@ -85,7 +85,7 @@ import           Foreign                    hiding (void)
 import           Kafka.Consumer.Convert     (fromMessagePtr, fromNativeTopicPartitionList'', offsetCommitToBool, offsetToInt64, toMap, toNativeTopicPartitionList, toNativeTopicPartitionList', toNativeTopicPartitionListNoDispose, topicPartitionFromMessageForCommit)
 import           Kafka.Consumer.Types       (KafkaConsumer (..))
 import           Kafka.Internal.RdKafka     (RdKafkaRespErrT (..), RdKafkaTopicPartitionListTPtr, RdKafkaTypeT (..), newRdKafkaT, newRdKafkaTopicPartitionListT, newRdKafkaTopicT, rdKafkaAssign, rdKafkaAssignment, rdKafkaCommit, rdKafkaCommitted, rdKafkaConfSetDefaultTopicConf, rdKafkaConsumeBatchQueue, rdKafkaConsumeQueue, rdKafkaConsumerClose, rdKafkaConsumerPoll, rdKafkaOffsetsStore, rdKafkaPausePartitions, rdKafkaPollSetConsumer, rdKafkaPosition, rdKafkaQueueDestroy, rdKafkaQueueNew, rdKafkaResumePartitions, rdKafkaSeek, rdKafkaSetLogLevel, rdKafkaSubscribe, rdKafkaSubscription, rdKafkaTopicConfDup, rdKafkaTopicPartitionListAdd)
-import           Kafka.Internal.Setup       (CallbackPollStatus (..), Kafka (..), KafkaConf (..), KafkaProps (..), TopicConf (..), TopicProps (..), getKafkaConf, getRdKafka, kafkaConf, topicConf)
+import           Kafka.Internal.Setup       (CallbackPollStatus (..), Kafka (..), KafkaConf (..), KafkaProps (..), TopicConf (..), TopicProps (..), getKafkaConf, getRdKafka, kafkaConf, topicConf, Callback(..))
 import           Kafka.Internal.Shared      (kafkaErrorToMaybe, maybeToLeft, rdKafkaErrorToEither)
 
 import Kafka.Consumer.ConsumerProperties as X
@@ -327,7 +327,7 @@ closeConsumer (KafkaConsumer (Kafka k) (KafkaConf _ qr statusVar)) = liftIO $
 newConsumerConf :: ConsumerProperties -> IO KafkaConf
 newConsumerConf ConsumerProperties {cpProps = m, cpCallbacks = cbs} = do
   conf <- kafkaConf (KafkaProps m)
-  forM_ cbs (\setCb -> setCb conf)
+  forM_ cbs (\(Callback setCb) -> setCb conf)
   return conf
 
 -- | Subscribes to a given list of topics.

--- a/src/Kafka/Consumer/ConsumerProperties.hs
+++ b/src/Kafka/Consumer/ConsumerProperties.hs
@@ -34,7 +34,7 @@ import           Data.Semigroup       as Sem
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Kafka.Consumer.Types (ConsumerGroupId (..))
-import           Kafka.Internal.Setup (KafkaConf (..))
+import           Kafka.Internal.Setup (KafkaConf (..), Callback(..))
 import           Kafka.Types          (BrokerAddress (..), ClientId (..), KafkaCompressionCodec (..), KafkaDebug (..), KafkaLogLevel (..), Millis (..), kafkaCompressionCodecToText, kafkaDebugToText)
 
 import Kafka.Consumer.Callbacks as X
@@ -53,7 +53,7 @@ data CallbackPollMode =
 data ConsumerProperties = ConsumerProperties
   { cpProps            :: Map Text Text
   , cpLogLevel         :: Maybe KafkaLogLevel
-  , cpCallbacks        :: [KafkaConf -> IO ()]
+  , cpCallbacks        :: [Callback]
   , cpCallbackPollMode :: CallbackPollMode
   }
 
@@ -117,7 +117,7 @@ clientId (ClientId cid) =
 -- * 'errorCallback'
 -- * 'logCallback'
 -- * 'statsCallback'
-setCallback :: (KafkaConf -> IO ()) -> ConsumerProperties
+setCallback :: Callback -> ConsumerProperties
 setCallback cb = mempty { cpCallbacks = [cb] }
 
 -- | Set the logging level.

--- a/src/Kafka/Internal/Setup.hs
+++ b/src/Kafka/Internal/Setup.hs
@@ -7,6 +7,7 @@ module Kafka.Internal.Setup
 , HasKafka(..)
 , HasKafkaConf(..)
 , HasTopicConf(..)
+, Callback(..)
 , CallbackPollStatus(..)
 , getRdKafka
 , getRdKafkaConf
@@ -45,6 +46,11 @@ newtype KafkaProps = KafkaProps (Map Text Text) deriving (Show, Eq)
 newtype TopicProps = TopicProps (Map Text Text) deriving (Show, Eq)
 newtype Kafka      = Kafka RdKafkaTPtr deriving Show
 newtype TopicConf  = TopicConf RdKafkaTopicConfTPtr deriving Show
+
+-- | Callbacks allow retrieving various information like error occurences, statistics
+-- and log messages.
+-- See `Kafka.Consumer.setCallback` (Consumer) and `Kafka.Producer.setCallback` (Producer) for more details.
+newtype Callback = Callback (KafkaConf -> IO ())
 
 data CallbackPollStatus = CallbackPollEnabled | CallbackPollDisabled deriving (Show, Eq)
 

--- a/src/Kafka/Producer.hs
+++ b/src/Kafka/Producer.hs
@@ -82,7 +82,7 @@ import           Foreign.Ptr              (Ptr, nullPtr, plusPtr)
 import           Foreign.Storable         (Storable (..))
 import           Foreign.StablePtr        (newStablePtr, castStablePtrToPtr)
 import           Kafka.Internal.RdKafka   (RdKafkaMessageT (..), RdKafkaRespErrT (..), RdKafkaTypeT (..), destroyUnmanagedRdKafkaTopic, newRdKafkaT, newUnmanagedRdKafkaTopicT, rdKafkaOutqLen, rdKafkaProduce, rdKafkaProduceBatch, rdKafkaSetLogLevel)
-import           Kafka.Internal.Setup     (Kafka (..), KafkaConf (..), KafkaProps (..), TopicConf (..), TopicProps (..), kafkaConf, topicConf)
+import           Kafka.Internal.Setup     (Kafka (..), KafkaConf (..), KafkaProps (..), TopicConf (..), TopicProps (..), kafkaConf, topicConf, Callback(..))
 import           Kafka.Internal.Shared    (pollEvents)
 import           Kafka.Producer.Convert   (copyMsgFlags, handleProduceErr', producePartitionCInt, producePartitionInt)
 import           Kafka.Producer.Types     (KafkaProducer (..), ImmediateError(..))
@@ -120,7 +120,7 @@ newProducer pps = liftIO $ do
   deliveryCallback (const mempty) kc
 
   -- set callbacks
-  forM_ (ppCallbacks pps) (\setCb -> setCb kc)
+  forM_ (ppCallbacks pps) (\(Callback setCb) -> setCb kc)
 
   mbKafka <- newRdKafkaT RdKafkaProducer kc'
   case mbKafka of

--- a/src/Kafka/Producer/ProducerProperties.hs
+++ b/src/Kafka/Producer/ProducerProperties.hs
@@ -27,7 +27,7 @@ import           Control.Monad            (MonadPlus(mplus))
 import           Data.Map                 (Map)
 import qualified Data.Map                 as M
 import           Data.Semigroup           as Sem
-import           Kafka.Internal.Setup     (KafkaConf(..))
+import           Kafka.Internal.Setup     (KafkaConf(..), Callback(..))
 import           Kafka.Types              (KafkaDebug(..), Timeout(..), KafkaCompressionCodec(..), KafkaLogLevel(..), BrokerAddress(..), kafkaDebugToText, kafkaCompressionCodecToText, Millis(..))
 
 import           Kafka.Producer.Callbacks
@@ -37,7 +37,7 @@ data ProducerProperties = ProducerProperties
   { ppKafkaProps :: Map Text Text
   , ppTopicProps :: Map Text Text
   , ppLogLevel   :: Maybe KafkaLogLevel
-  , ppCallbacks  :: [KafkaConf -> IO ()]
+  , ppCallbacks  :: [Callback]
   }
 
 instance Sem.Semigroup ProducerProperties where
@@ -70,7 +70,7 @@ brokersList bs =
 -- * 'errorCallback'
 -- * 'logCallback'
 -- * 'statsCallback'
-setCallback :: (KafkaConf -> IO ()) -> ProducerProperties
+setCallback :: Callback -> ProducerProperties
 setCallback cb = mempty { ppCallbacks = [cb] }
 
 -- | Sets the logging level.


### PR DESCRIPTION
I was at first struggling to use the callbacks correctly. Granted, this was mostly my fault as I looked at the wrong hackage version of hw-client which did not yet have the examples in the doc on how to use the callbacks. But anyway, I find having the ` ... -> k -> IO ()` in the type signature a bit confusing. I was basically doing:

```
producer <- newProducer ...
statsCallback cb producer
```

instead of using `setCallback` and the producer properties.

I think just wrapping the callbacks in a newtype makes it hard (impossible?) to make this mistake and improves readability. What do you think?

PS: Backward-compatiblity is only affected if people gave explicity type signatures for any variable containing the callback. If one just directly passes the callback to `setCallback` no change is required. E.g.:
```
  -- Global producer properties
  producerProps :: ProducerProperties
  producerProps = brokersList [BrokerAddress "localhost:9092"]
               <> sendTimeout (Timeout 10000)
               <> setCallback (deliveryCallback print)
               <> logLevel KafkaLogDebug
```
stil compiles.