### PR TITLE
Fix shutdown crash when log/error callback is set

### DIFF
--- a/scripts/build-librdkafka
+++ b/scripts/build-librdkafka
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RDKAFKA_VER="7478b5ef16aadd6543fe38bc6a2deb895c70da98"
+RDKAFKA_VER="849c066b559950b02e37a69256f0cb7b04381d0e"
 
 PRJ=$PWD
 DST="$PRJ/.librdkafka"


### PR DESCRIPTION
The rd_kafka_destroy method may call back into Haskell to perform some logging. This is not allowed when attaching the finalizer
using Foreign.ForeignPtr. Hence we switch to Foreign.Concurrent, which allows RdKafka to call back into Haskell. We also disable
closing the consumer automatically in the finalizer, this should be done by the application by calling `closeConsumer` explicitly.