### PR TITLE
Add headers to consumed/produced records

### DIFF
--- a/example/ProducerExample.hs
+++ b/example/ProducerExample.hs
@@ -61,6 +61,8 @@ sendMessages prod = do
   putStrLn "And the last one..."
   msg3 <- getLine
   err3 <- produceMessage prod (mkMessage (Just "key3") (Just $ pack msg3))
+  
+  err4 <- produceMessageWithHeaders prod (headersFromList [("fancy", "header")]) (mkMessage (Just "key4") (Just $ pack msg3))
 
   -- errs <- produceMessageBatch prod
   --           [ mkMessage (Just "b-1") (Just "batch-1")

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,26 @@
 {
-    "niv": {
-        "branch": "master",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "nmattia",
-        "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
-        "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "release-19.03",
-        "description": "Nix Packages collection",
-        "homepage": "",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "da0c385a691d38b56b17eb18b852c4cec2050c24",
-        "sha256": "0svhqn139cy2nlgv4kqv1bsxza2dcm0yylrhnmanw4p73gv85caf",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/da0c385a691d38b56b17eb18b852c4cec2050c24.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    }
+  "niv": {
+    "branch": "master",
+    "description": "Easy dependency management for Nix projects",
+    "homepage": "https://github.com/nmattia/niv",
+    "owner": "nmattia",
+    "repo": "niv",
+    "rev": "e0ca65c81a2d7a4d82a189f1e23a48d59ad42070",
+    "sha256": "1pq9nh1d8nn3xvbdny8fafzw87mj7gsmp6pxkdl65w2g18rmcmzx",
+    "type": "tarball",
+    "url": "https://github.com/nmattia/niv/archive/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "nixpkgs": {
+    "branch": "nixos-21.05",
+    "description": "Nix Packages collection",
+    "homepage": "",
+    "owner": "NixOS",
+    "repo": "nixpkgs",
+    "rev": "d5aadbefd650cb0a05ba9c788a26327afce2396c",
+    "sha256": "1h9nvs7nknczpz15c41p3irbykc5qzwr8wlcpzxndc25mnqi257w",
+    "type": "tarball",
+    "url": "https://github.com/NixOS/nixpkgs/archive/d5aadbefd650cb0a05ba9c788a26327afce2396c.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ pkgs.mkShell {
     rdkafka
     nettools
     niv
+    gmp
   ];
 
   shellHook = ''

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -37,14 +37,13 @@ where
 import Data.Bifoldable      (Bifoldable (..))
 import Data.Bifunctor       (Bifunctor (..))
 import Data.Bitraversable   (Bitraversable (..), bimapM, bisequence)
-import Data.ByteString      (ByteString)
 import Data.Int             (Int64)
 import Data.String          (IsString)
 import Data.Text            (Text)
 import Data.Typeable        (Typeable)
 import GHC.Generics         (Generic)
 import Kafka.Internal.Setup (HasKafka (..), HasKafkaConf (..), Kafka (..), KafkaConf (..))
-import Kafka.Types          (Millis (..), PartitionId (..), TopicName (..))
+import Kafka.Types          (Millis (..), PartitionId (..), TopicName (..), Headers)
 
 -- | The main type for Kafka consumption, used e.g. to poll and commit messages.
 -- 
@@ -140,13 +139,13 @@ data TopicPartition = TopicPartition
 
 -- | Represents a /received/ message from Kafka (i.e. used in a consumer)
 data ConsumerRecord k v = ConsumerRecord
-  { crTopic     :: !TopicName                  -- ^ Kafka topic this message was received from
-  , crPartition :: !PartitionId                -- ^ Kafka partition this message was received from
-  , crOffset    :: !Offset                     -- ^ Offset within the 'crPartition' Kafka partition
-  , crTimestamp :: !Timestamp                  -- ^ Message timestamp
-  , crHeaders   :: ![(ByteString, ByteString)] -- ^ Message headers
-  , crKey       :: !k                          -- ^ Message key
-  , crValue     :: !v                          -- ^ Message value
+  { crTopic     :: !TopicName    -- ^ Kafka topic this message was received from
+  , crPartition :: !PartitionId  -- ^ Kafka partition this message was received from
+  , crOffset    :: !Offset       -- ^ Offset within the 'crPartition' Kafka partition
+  , crTimestamp :: !Timestamp    -- ^ Message timestamp
+  , crHeaders   :: !Headers      -- ^ Message headers
+  , crKey       :: !k            -- ^ Message key
+  , crValue     :: !v            -- ^ Message value
   }
   deriving (Eq, Show, Read, Typeable, Generic)
 

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -37,6 +37,7 @@ where
 import Data.Bifoldable      (Bifoldable (..))
 import Data.Bifunctor       (Bifunctor (..))
 import Data.Bitraversable   (Bitraversable (..), bimapM, bisequence)
+import Data.ByteString      (ByteString)
 import Data.Int             (Int64)
 import Data.String          (IsString)
 import Data.Text            (Text)
@@ -139,17 +140,18 @@ data TopicPartition = TopicPartition
 
 -- | Represents a /received/ message from Kafka (i.e. used in a consumer)
 data ConsumerRecord k v = ConsumerRecord
-  { crTopic     :: !TopicName    -- ^ Kafka topic this message was received from
-  , crPartition :: !PartitionId  -- ^ Kafka partition this message was received from
-  , crOffset    :: !Offset       -- ^ Offset within the 'crPartition' Kafka partition
-  , crTimestamp :: !Timestamp    -- ^ Message timestamp
-  , crKey       :: !k            -- ^ Message key
-  , crValue     :: !v            -- ^ Message value
+  { crTopic     :: !TopicName                  -- ^ Kafka topic this message was received from
+  , crPartition :: !PartitionId                -- ^ Kafka partition this message was received from
+  , crOffset    :: !Offset                     -- ^ Offset within the 'crPartition' Kafka partition
+  , crTimestamp :: !Timestamp                  -- ^ Message timestamp
+  , crHeaders   :: ![(ByteString, ByteString)] -- ^ Message headers
+  , crKey       :: !k                          -- ^ Message key
+  , crValue     :: !v                          -- ^ Message value
   }
   deriving (Eq, Show, Read, Typeable, Generic)
 
 instance Bifunctor ConsumerRecord where
-  bimap f g (ConsumerRecord t p o ts k v) =  ConsumerRecord t p o ts (f k) (g v)
+  bimap f g (ConsumerRecord t p o ts hds k v) =  ConsumerRecord t p o ts hds (f k) (g v)
   {-# INLINE bimap #-}
 
 instance Functor (ConsumerRecord k) where

--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -975,10 +975,7 @@ newRdKafkaTopicT kafkaPtr topic topicConfPtr = do
     return res
 
 -------------------------------------------------------------------------------------------------
----- Headers
-
-data RdKafkaHeadersT
-{#pointer *rd_kafka_headers_t as RdKafkaHeadersTPtr foreign -> RdKafkaHeadersT #}
+---- Errors
 
 data RdKafkaErrorT
 {#pointer *rd_kafka_error_t as RdKafkaErrorTPtr foreign -> RdKafkaErrorT #}
@@ -988,6 +985,12 @@ foreign import ccall "rdkafka.h &rd_kafka_error_destroy"
 
 foreign import ccall "rdkafka.h rd_kafka_error_destroy"
     rdKafkaErrorDestroy :: Ptr RdKafkaErrorT -> IO ()
+
+-------------------------------------------------------------------------------------------------
+---- Headers
+
+data RdKafkaHeadersT
+{#pointer *rd_kafka_headers_t as RdKafkaHeadersTPtr -> RdKafkaHeadersT #}
 
 {#fun rd_kafka_headers_new as ^
     {`Int'} -> `RdKafkaHeadersTPtr' #}
@@ -1010,15 +1013,8 @@ foreign import ccall "rdkafka.h rd_kafka_headers_destroy"
 {#fun rd_kafka_message_set_headers as ^
     {`RdKafkaMessageTPtr', `RdKafkaHeadersTPtr'} -> `()' #}
 
-{#fun rd_kafka_message_detach_headers as rdKafkaMessageDetachHeaders'
-    {`RdKafkaMessageTPtr', alloca- `Ptr RdKafkaHeadersT' peekPtr*} -> `RdKafkaRespErrT' cIntToEnum #}
-
-rdKafkaMessageHeaders :: RdKafkaMessageTPtr -> IO (Either RdKafkaRespErrT RdKafkaHeadersTPtr)
-rdKafkaMessageHeaders msgPt = do
-    (err, res) <- rdKafkaMessageDetachHeaders' msgPt
-    case err of
-        RdKafkaRespErrNoError -> Right <$> newForeignPtr res (rdKafkaHeadersDestroy res)
-        e -> return $ Left e
+{#fun rd_kafka_message_headers as ^
+    {`RdKafkaMessageTPtr', alloca- `RdKafkaHeadersTPtr' peekPtr*} -> `RdKafkaRespErrT' cIntToEnum #}
 
 --- Producev api
 

--- a/src/Kafka/Internal/Shared.hs
+++ b/src/Kafka/Internal/Shared.hs
@@ -10,6 +10,7 @@ module Kafka.Internal.Shared
 , kafkaErrorToEither
 , kafkaErrorToMaybe
 , maybeToLeft
+, readHeaders
 , readPayload
 , readTopic
 , readKey
@@ -107,11 +108,11 @@ readTimestamp msg =
 
 readHeaders :: RdKafkaMessageTPtr -> IO (Either RdKafkaRespErrT [(BS.ByteString, BS.ByteString)])
 readHeaders msg = do
-    eiHeaders <- rdKafkaMessageHeaders msg
-    case eiHeaders of 
-        Left RdKafkaRespErrNoent -> return $ Right []
-        Left e -> return $ Left e
-        Right ptHeaders -> extractHeaders ptHeaders
+    (err, headersPtr) <- rdKafkaMessageHeaders msg
+    case err of 
+        RdKafkaRespErrNoent -> return $ Right []
+        RdKafkaRespErrNoError -> extractHeaders headersPtr
+        e -> return $ Left e
     where extractHeaders ptHeaders = 
             alloca $ \nptr -> 
                 alloca $ \vptr -> 

--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -21,6 +21,7 @@ module Kafka.Types
 , KafkaDebug(..)
 , KafkaCompressionCodec(..)
 , TopicType(..)
+, Headers(unHeaders), headersFromList, headersToList
 , topicType
 , kafkaDebugToText
 , kafkaCompressionCodecToText
@@ -34,6 +35,7 @@ import Data.Text              (Text, isPrefixOf)
 import Data.Typeable          (Typeable)
 import GHC.Generics           (Generic)
 import Kafka.Internal.RdKafka (RdKafkaRespErrT, rdKafkaErr2name, rdKafkaErr2str)
+import qualified Data.ByteString as BS
 
 -- | Kafka broker ID
 newtype BrokerId = BrokerId { unBrokerId :: Int } deriving (Show, Eq, Ord, Read, Generic)
@@ -158,4 +160,14 @@ kafkaCompressionCodecToText c = case c of
   NoCompression -> "none"
   Gzip          -> "gzip"
   Snappy        -> "snappy"
-  Lz4           -> "lz4"
+  Lz4           -> "lz4" 
+
+-- | Headers that might be passed along with a record
+newtype Headers = Headers { unHeaders :: [(BS.ByteString, BS.ByteString)] } 
+  deriving (Eq, Show, Semigroup, Monoid, Read, Typeable, Generic)
+
+headersFromList :: [(BS.ByteString, BS.ByteString)] -> Headers
+headersFromList = Headers
+
+headersToList :: Headers -> [(BS.ByteString, BS.ByteString)]
+headersToList = unHeaders

--- a/tests/Kafka/Consumer/ConsumerRecordMapSpec.hs
+++ b/tests/Kafka/Consumer/ConsumerRecordMapSpec.hs
@@ -19,6 +19,7 @@ testRecord = ConsumerRecord
   , crPartition = PartitionId 0
   , crOffset    = Offset 5
   , crTimestamp = NoTimestamp
+  , crHeaders   = mempty
   , crKey       = Just testKey
   , crValue     = Just testValue
   }

--- a/tests/Kafka/Consumer/ConsumerRecordTraverseSpec.hs
+++ b/tests/Kafka/Consumer/ConsumerRecordTraverseSpec.hs
@@ -21,6 +21,7 @@ testRecord = ConsumerRecord
   , crPartition = PartitionId 0
   , crOffset    = Offset 5
   , crTimestamp = NoTimestamp
+  , crHeaders   = mempty
   , crKey       = testKey
   , crValue     = testValue
   }


### PR DESCRIPTION
Closes #58
### Implementation details
1. I'm using [rd_kafka_produceva] bindings (https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L4397) (which is identical to [rd_kafka_producev](https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L4382), besides structure passings instead of varargs) as regular rd_kafka_produce message doesn't support headers.
2. [rd_kafka_produce_batch](https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L4428) does not allow passing headers as well so I left `ProduceRecord` as is. Instead I've added a separate `produceWithHeaders` to cover the case when singular message is produced with headers.
3. Consumer record now has `crHeaders` field which is a breaking change, but I don't really see how this can be done differently without duplicating the existing api.