### PR TITLE
Can alter offsets on RebalanceBeforeAssign.

### DIFF
--- a/src/Kafka/Consumer.hs
+++ b/src/Kafka/Consumer.hs
@@ -118,7 +118,7 @@ newConsumer :: MonadIO m
             -> m (Either KafkaError KafkaConsumer)
 newConsumer props (Subscription ts tp) = liftIO $ do
   let cp = case cpCallbackPollMode props of
-            CallbackPollModeAsync -> setCallback (rebalanceCallback (\_ _ -> return ())) <> props
+            CallbackPollModeAsync -> setCallback (rebalanceCallback (\_ _ -> return Nothing)) <> props
             CallbackPollModeSync  -> props
   kc@(KafkaConf kc' qref _) <- newConsumerConf cp
   tp' <- topicConf (TopicProps tp)

--- a/src/Kafka/Consumer/Types.hs
+++ b/src/Kafka/Consumer/Types.hs
@@ -72,20 +72,20 @@ newtype ConsumerGroupId = ConsumerGroupId
 newtype Offset          = Offset { unOffset :: Int64 } deriving (Show, Eq, Ord, Read, Generic)
 
 -- | Where to reset the offset when there is no initial offset in Kafka
--- 
+--
 -- See <https://kafka.apache.org/documentation/#auto.offset.reset Kafka documentation on offset reset>
 data OffsetReset        = Earliest | Latest deriving (Show, Eq, Generic)
 
 -- | A set of events which happen during the rebalancing process
 data RebalanceEvent =
     -- | Happens before Kafka Client confirms new assignment
-    RebalanceBeforeAssign [(TopicName, PartitionId)]
+    RebalanceBeforeAssign [TopicPartition]
     -- | Happens after the new assignment is confirmed
-  | RebalanceAssign [(TopicName, PartitionId)]
+  | RebalanceAssign [TopicPartition]
     -- | Happens before Kafka Client confirms partitions rejection
-  | RebalanceBeforeRevoke [(TopicName, PartitionId)]
+  | RebalanceBeforeRevoke [TopicPartition]
     -- | Happens after the rejection is confirmed
-  | RebalanceRevoke [(TopicName, PartitionId)]
+  | RebalanceRevoke [TopicPartition]
   deriving (Eq, Show, Generic)
 
 -- | The partition offset


### PR DESCRIPTION
This is useful if you don't want the broker to manage group offsets on
your behalf, but you rather store the offsets locally (typically in a
transaction together with the effects of the processing of that batch of
messages).

See the documentation of rd_kafka_conf_set_rebalance_cb
(https://docs.confluent.io/2.0.0/clients/librdkafka/rdkafka_8h.html#a10db731dc1a295bd9884e4f8cb199311).