### PR TITLE
zstd support

### DIFF
--- a/src/Kafka/Types.hs
+++ b/src/Kafka/Types.hs
@@ -150,6 +150,7 @@ data KafkaCompressionCodec =
   | Gzip
   | Snappy
   | Lz4
+  | Zstd
   deriving (Eq, Show, Typeable, Generic)
 
 -- | Convert a 'KafkaCompressionCodec' into its /librdkafka/ string equivalent.
@@ -161,6 +162,7 @@ kafkaCompressionCodecToText c = case c of
   Gzip          -> "gzip"
   Snappy        -> "snappy"
   Lz4           -> "lz4" 
+  Zstd          -> "zstd"
 
 -- | Headers that might be passed along with a record
 newtype Headers = Headers { unHeaders :: [(BS.ByteString, BS.ByteString)] } 


### PR DESCRIPTION
`rdkafka` [already supports](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties) `zstd` codec, we should allow it on the Haskell side

Closes #171