### PR TITLE
Adding support for cooperative partition reassignment strategy

### DIFF
--- a/src/Kafka/Internal/RdKafka.chs
+++ b/src/Kafka/Internal/RdKafka.chs
@@ -611,6 +611,9 @@ pollRdKafkaConsumer k t = do
     {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'}
     -> `RdKafkaRespErrT' cIntToEnum #}
 
+{#fun rd_kafka_rebalance_protocol as ^
+    {`RdKafkaTPtr'} -> `String' #}
+
 {#fun rd_kafka_assignment as rdKafkaAssignment'
     {`RdKafkaTPtr', alloca- `Ptr RdKafkaTopicPartitionListT' peekPtr* }
     -> `RdKafkaRespErrT' cIntToEnum #}
@@ -1100,6 +1103,13 @@ rdKafkaMessageProduceVa kafkaPtr vts = withArrayLen vts $ \i arrPtr -> do
 
 {#fun rd_kafka_abort_transaction as rdKafkaAbortTransaction
     {`RdKafkaTPtr', `Int'} -> `RdKafkaErrorTPtr' #}
+
+{#fun rd_kafka_incremental_assign as ^
+    {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'} -> `RdKafkaErrorTPtr' #}
+
+{#fun rd_kafka_incremental_unassign as ^
+    {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'}
+    -> `RdKafkaErrorTPtr' #}
 
 {#fun rd_kafka_consumer_group_metadata as rdKafkaConsumerGroupMetadata
     {`RdKafkaTPtr'} -> `Ptr ()' #}


### PR DESCRIPTION
Current implementation does not support coorporative-sticky assignment strategy. To added a support for the same creating this pr.

`partition.assignment.strategy=cooperative-sticky`

